### PR TITLE
Changed IronRDP printer handling

### DIFF
--- a/rustconn-core/src/rdp_client/client/connection.rs
+++ b/rustconn-core/src/rdp_client/client/connection.rs
@@ -1,6 +1,6 @@
 use super::super::audio::RustConnAudioBackend;
 use super::super::clipboard::RustConnClipboardBackend;
-use super::super::rdpdr::RustConnRdpdrBackend;
+use super::super::rdpdr::{RustConnRdpdrBackend, cups_default_printer, list_cups_printers};
 use super::super::{RdpClientConfig, RdpClientError, RdpClientEvent};
 use ironrdp::cliprdr::CliprdrClient;
 use ironrdp::connector::{
@@ -136,18 +136,56 @@ pub async fn establish_connection(
             })
             .collect();
 
-        let rdpdr_backend = RustConnRdpdrBackend::new(drive_paths);
+        // Build the printer device_id -> CUPS queue map. Printer IDs sit past
+        // the drive IDs (drives occupy 1..=N) so they never collide. Each
+        // forwarded queue is announced as its own redirected printer, and the
+        // backend uses this map to route each job back to the right local queue.
+        let mut printer_queues: std::collections::HashMap<u32, String> =
+            std::collections::HashMap::new();
+        if config.printer_enabled {
+            let base = config.shared_folders.len() as u32;
+
+            // Decide which queues to forward: an explicit subset, or all local
+            // queues when none are listed.
+            let mut queues = if config.printers.is_empty() {
+                list_cups_printers()
+            } else {
+                config.printers.clone()
+            };
+
+            // Announce the CUPS default LAST so it wins IronRDP's hardcoded
+            // DEFAULTPRINTER flag race (see plan Appendix A).
+            if let Some(default) = cups_default_printer()
+                && let Some(pos) = queues.iter().position(|q| *q == default)
+            {
+                let d = queues.remove(pos);
+                queues.push(d);
+            }
+
+            for (idx, queue) in queues.into_iter().enumerate() {
+                let device_id = base + 1 + idx as u32;
+                printer_queues.insert(device_id, queue);
+            }
+        }
+
+        let rdpdr_backend = RustConnRdpdrBackend::new(drive_paths, printer_queues.clone());
         let mut rdpdr = Rdpdr::new(Box::new(rdpdr_backend), computer_name);
         if !initial_drives.is_empty() {
             rdpdr = rdpdr.with_drives(Some(initial_drives));
         }
-        if config.printer_enabled {
-            // Printer device id sits past the drive ids (1..=n). The backend
-            // accumulates the PostScript spool and forwards it to CUPS on close.
-            let printer_device_id = config.shared_folders.len() as u32 + 1;
-            rdpdr = rdpdr.with_printer(printer_device_id, "RustConn".to_string());
-            tracing::debug!("RDPDR: registering printer device {}", printer_device_id);
+
+        // Announce each forwarded printer. Sort by device_id so announce order
+        // is deterministic and matches the "default announced last" intent.
+        let mut announce: Vec<(u32, String)> = printer_queues
+            .iter()
+            .map(|(id, q)| (*id, q.clone()))
+            .collect();
+        announce.sort_by_key(|(id, _)| *id);
+        for (device_id, queue) in announce {
+            tracing::debug!("RDPDR: registering printer {device_id} -> '{queue}'");
+            rdpdr = rdpdr.with_printer(device_id, queue);
         }
+
         connector.static_channels.insert(rdpdr);
     } else if config.audio_enabled {
         // No shared folders but audio is enabled - add RDPSND channel

--- a/rustconn-core/src/rdp_client/config.rs
+++ b/rustconn-core/src/rdp_client/config.rs
@@ -132,6 +132,11 @@ pub struct RdpClientConfig {
     #[serde(default)]
     pub printer_enabled: bool,
 
+    /// Specific CUPS queue names to forward. When empty and `printer_enabled`
+    /// is true, all local queues are forwarded.
+    #[serde(default)]
+    pub printers: Vec<String>,
+
     /// Enable smart card redirection
     #[serde(default)]
     pub smartcard_enabled: bool,
@@ -247,6 +252,7 @@ impl Default for RdpClientConfig {
             monitor_layout: MonitorLayout::default(),
             reconnect_policy: ReconnectPolicy::default(),
             printer_enabled: false,
+            printers: Vec::new(),
             smartcard_enabled: false,
             microphone_enabled: false,
             remote_app: None,
@@ -407,6 +413,16 @@ impl RdpClientConfig {
         self
     }
 
+    /// Restricts printer redirection to the named CUPS queues.
+    ///
+    /// An empty list (the default) forwards all local queues when
+    /// `printer_enabled` is true.
+    #[must_use]
+    pub fn with_printers(mut self, queues: Vec<String>) -> Self {
+        self.printers = queues;
+        self
+    }
+
     /// Enables or disables smart card redirection
     #[must_use]
     pub const fn with_smartcard(mut self, enabled: bool) -> Self {
@@ -521,6 +537,7 @@ impl PartialEq for RdpClientConfig {
             && self.monitor_layout == other.monitor_layout
             && self.reconnect_policy == other.reconnect_policy
             && self.printer_enabled == other.printer_enabled
+            && self.printers == other.printers
             && self.smartcard_enabled == other.smartcard_enabled
             && self.microphone_enabled == other.microphone_enabled
             && self.remote_app == other.remote_app

--- a/rustconn-core/src/rdp_client/rdpdr.rs
+++ b/rustconn-core/src/rdp_client/rdpdr.rs
@@ -64,6 +64,9 @@ pub struct RustConnRdpdrBackend {
     /// The server streams a PostScript document via Write IRPs; we buffer it
     /// and hand it to CUPS on Close.
     print_jobs: HashMap<u32, Vec<u8>>,
+    /// Map of printer device IDs to their local CUPS queue names.
+    /// Used to route each print job back to the correct local queue on Close.
+    printer_queues: HashMap<u32, String>,
     /// Directory watcher for change notifications
     dir_watcher: Option<DirectoryWatcher>,
 }
@@ -83,9 +86,13 @@ struct PendingNotification {
 impl_as_any!(RustConnRdpdrBackend);
 
 impl RustConnRdpdrBackend {
-    /// Creates a new RDPDR backend with drive paths mapped by device ID
+    /// Creates a new RDPDR backend with drive paths and printer queues mapped
+    /// by device ID.
     #[must_use]
-    pub fn new(drive_paths: HashMap<u32, String>) -> Self {
+    pub fn new(
+        drive_paths: HashMap<u32, String>,
+        printer_queues: HashMap<u32, String>,
+    ) -> Self {
         // Ensure all paths end with /
         let drive_paths: HashMap<u32, String> = drive_paths
             .into_iter()
@@ -126,6 +133,7 @@ impl RustConnRdpdrBackend {
             dir_entries: HashMap::new(),
             pending_notifications: HashMap::new(),
             print_jobs: HashMap::new(),
+            printer_queues,
             dir_watcher,
         }
     }
@@ -283,8 +291,11 @@ impl RdpdrBackend for RustConnRdpdrBackend {
                 ))])
             }
             PrinterIoRequest::Close(close_req) => {
-                // Job finished — hand the accumulated document to CUPS.
+                // Job finished — hand the accumulated document to the matching
+                // local CUPS queue (falling back to the default when unknown).
                 let file_id = close_req.device_io_request.file_id;
+                let device_id = close_req.device_io_request.device_id;
+                let queue = self.printer_queues.get(&device_id).cloned();
                 if let Some(job) = self.print_jobs.remove(&file_id)
                     && !job.is_empty()
                 {
@@ -293,7 +304,7 @@ impl RdpdrBackend for RustConnRdpdrBackend {
                     // active session runs on a single-threaded runtime — doing
                     // it inline would stall framebuffer updates and input until
                     // `lp` returns. Best-effort, so the handle is detached.
-                    std::thread::spawn(move || spool_to_cups(&job));
+                    std::thread::spawn(move || spool_to_cups(&job, queue.as_deref()));
                 }
                 Ok(vec![SvcMessage::from(RdpdrPdu::DeviceCloseResponse(
                     DeviceCloseResponse {
@@ -1119,18 +1130,25 @@ fn get_file_attributes(meta: &std::fs::Metadata, file_name: &str) -> FileAttribu
     attrs
 }
 
-/// Sends an accumulated print job to the local CUPS spooler.
+/// Sends an accumulated print job to a local CUPS queue (or the default queue
+/// when `queue` is `None`).
 ///
 /// The virtual printer is announced with a PostScript driver, so the buffer
 /// holds a PostScript document that `lp` can consume directly. Best-effort:
 /// failures are logged but never surfaced to the RDP session.
 ///
-// ponytail: shells out to CUPS `lp` (default printer); fine for the common
-// Linux desktop. A native IPP client would drop the runtime dependency on
-// cups-client but pulls in another crate — not worth it until users ask.
-fn spool_to_cups(document: &[u8]) {
-    let mut child = match Command::new("lp")
-        .args(["-t", "RustConn RDP"])
+// ponytail: shells out to CUPS `lp`; fine for the common Linux desktop. A
+// native IPP client would drop the runtime dependency on cups-client but pulls
+// in another crate — not worth it until users ask.
+fn spool_to_cups(document: &[u8], queue: Option<&str>) {
+    let mut cmd = Command::new("lp");
+    cmd.args(["-t", "RustConn RDP"]);
+    if let Some(q) = queue {
+        // Route to the matching local queue. Passed as a single argument so
+        // queue names with spaces or odd characters are handled safely.
+        cmd.args(["-d", q]);
+    }
+    let mut child = match cmd
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -1152,9 +1170,92 @@ fn spool_to_cups(document: &[u8]) {
 
     match child.wait() {
         Ok(status) if status.success() => {
-            debug!("RDP print job sent to CUPS ({} bytes)", document.len());
+            debug!(
+                "RDP print job sent to CUPS queue {:?} ({} bytes)",
+                queue.unwrap_or("<default>"),
+                document.len()
+            );
         }
         Ok(status) => warn!("`lp` exited with {status} for RDP print job"),
         Err(e) => warn!("Failed to wait for `lp`: {e}"),
+    }
+}
+
+/// Lists local CUPS print queues, one destination per line via `lpstat -e`.
+///
+/// Returns an empty vector if `lpstat` is unavailable or fails; callers should
+/// treat that as "no printers to forward" rather than an error.
+pub(crate) fn list_cups_printers() -> Vec<String> {
+    let output = match Command::new("lpstat").arg("-e").output() {
+        Ok(o) => o,
+        Err(e) => {
+            warn!("`lpstat -e` failed ({e}); no printers will be forwarded");
+            return Vec::new();
+        }
+    };
+    parse_cups_printers(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// Parses the destination list emitted by `lpstat -e` (one queue per line).
+fn parse_cups_printers(stdout: &str) -> Vec<String> {
+    stdout
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+/// Returns the CUPS default destination name from `lpstat -d`, if any.
+///
+/// Used only to decide announce ordering (default announced last so it wins the
+/// IronRDP `DEFAULTPRINTER` flag race).
+pub(crate) fn cups_default_printer() -> Option<String> {
+    let output = Command::new("lpstat").arg("-d").output().ok()?;
+    parse_cups_default(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// Parses the default destination from `lpstat -d` output.
+///
+/// Format: `system default destination: <name>` or
+/// `no system default destination`.
+fn parse_cups_default(stdout: &str) -> Option<String> {
+    stdout
+        .split(':')
+        .nth(1)
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+}
+
+#[cfg(test)]
+mod printer_tests {
+    use super::{parse_cups_default, parse_cups_printers};
+
+    #[test]
+    fn parses_multiline_printer_list() {
+        let out = "Office_LaserJet\n  PDF \n\nKitchen_Inkjet\n";
+        assert_eq!(
+            parse_cups_printers(out),
+            vec!["Office_LaserJet", "PDF", "Kitchen_Inkjet"]
+        );
+    }
+
+    #[test]
+    fn empty_printer_list() {
+        assert!(parse_cups_printers("").is_empty());
+        assert!(parse_cups_printers("\n  \n").is_empty());
+    }
+
+    #[test]
+    fn parses_default_printer() {
+        assert_eq!(
+            parse_cups_default("system default destination: Office_LaserJet\n").as_deref(),
+            Some("Office_LaserJet")
+        );
+    }
+
+    #[test]
+    fn no_default_printer() {
+        assert_eq!(parse_cups_default("no system default destination\n"), None);
     }
 }

--- a/rustconn-core/tests/properties/rdp_client_tests.rs
+++ b/rustconn-core/tests/properties/rdp_client_tests.rs
@@ -128,6 +128,7 @@ fn arb_rdp_client_config() -> impl Strategy<Value = RdpClientConfig> {
                     monitor_layout: Default::default(),
                     reconnect_policy: Default::default(),
                     printer_enabled: false,
+                    printers: Vec::new(),
                     smartcard_enabled: false,
                     microphone_enabled: false,
                     remote_app: None,

--- a/rustconn/src/window/credentials.rs
+++ b/rustconn/src/window/credentials.rs
@@ -647,6 +647,25 @@ impl MainWindow {
         if let Some(ref creds) = resolved_credentials
             && let (Some(username), Some(password)) = (&creds.username, creds.expose_password())
         {
+            // The vault stores only username + password (domain is saved as
+            // None — see save_password_to_vault), so the domain must come from
+            // the connection config. Without it, NLA/CredSSP logs in as the
+            // bare user instead of DOMAIN\user and the server rejects it with
+            // STATUS_LOGON_FAILURE (0xC000006D). The manual/prompt path already
+            // forwards conn.domain, so this keeps the vault path consistent.
+            let domain = creds
+                .domain
+                .clone()
+                .or_else(|| {
+                    state
+                        .try_borrow()
+                        .ok()
+                        .and_then(|s| {
+                            s.get_connection(connection_id)
+                                .and_then(|c| c.domain.clone())
+                        })
+                })
+                .unwrap_or_default();
             Self::start_rdp_session_with_credentials(
                 &state,
                 &notebook,
@@ -655,7 +674,7 @@ impl MainWindow {
                 connection_id,
                 username,
                 password,
-                "",
+                &domain,
             );
             return;
         }


### PR DESCRIPTION
previously only one "dummy" printer was initialized in the RDP connection which is now changed to properly serialize all CUPS printers and forward them correctly to the RDP server. 

Fixes #192 

somehow my other change was also committed. Sorry for that.

It fixed a problem for RDP connections using saved passwords via "Tresor" to send an empty domain name instead of the one configured.

Possible fix for #188 