### PR TITLE
Changed RDP connection screen size

### DIFF
--- a/rustconn/src/embedded_rdp/connection.rs
+++ b/rustconn/src/embedded_rdp/connection.rs
@@ -314,10 +314,10 @@ impl super::EmbeddedRdpWidget {
                     reason = "value range fits the target type and is non-negative by construction in this code path"
                 )]
                 let device_h = (f64::from(h.unsigned_abs()) * effective_scale) as u32;
-                // Round down to multiple of 4 for RDP compatibility
-                // Many RDP servers and codecs require dimensions divisible by 4
-                let width = (device_w / 4) * 4;
-                let height = (device_h / 4) * 4;
+                // Exact widget size; MS-RDPEDISP requires even width, so clear
+                // its low bit. Height is used as-is.
+                let width = device_w & !1;
+                let height = device_h;
                 // Clamp to reasonable maximum (8K) and ensure minimum size
                 (width.clamp(640, 7680), height.clamp(480, 4320))
             } else {
@@ -648,6 +648,85 @@ impl super::EmbeddedRdpWidget {
                                     let mut cbuf = cairo_buffer.borrow_mut();
                                     cbuf.resize(server_w, server_h);
                                     cbuf.clear();
+                                }
+
+                                // Snap the desktop to the drawing area's real size.
+                                // The initial resolution was measured before the
+                                // (permanent) toolbar was shown, so the server's
+                                // desktop is too tall for the now-shrunk drawing area
+                                // — that mismatch blurs the first frame, and it's
+                                // below RESIZE_THRESHOLD_PX so the resize handler never
+                                // corrects it. Layout has settled by now, so re-request
+                                // the true size over Display Control for a 1:1 map.
+                                // No-op when it already matches (e.g. reconnect).
+                                {
+                                    let effective_scale = config.borrow().as_ref().map_or_else(
+                                        || f64::from(drawing_area.scale_factor().max(1)),
+                                        |c| {
+                                            c.scale_override
+                                                .effective_scale(drawing_area.scale_factor())
+                                        },
+                                    );
+                                    let css_w = drawing_area.width().unsigned_abs();
+                                    let css_h = drawing_area.height().unsigned_abs();
+                                    #[expect(
+                                        clippy::cast_possible_truncation,
+                                        clippy::cast_sign_loss,
+                                        reason = "value range fits the target type and is non-negative by construction in this code path"
+                                    )]
+                                    // Exact size; width even (MS-RDPEDISP), height as-is.
+                                    let settled_w =
+                                        (f64::from(css_w) * effective_scale) as u32 & !1;
+                                    #[expect(
+                                        clippy::cast_possible_truncation,
+                                        clippy::cast_sign_loss,
+                                        reason = "value range fits the target type and is non-negative by construction in this code path"
+                                    )]
+                                    let settled_h = (f64::from(css_h) * effective_scale) as u32;
+
+                                    // Only when realized, a sane size, and actually
+                                    // different (tolerance absorbs the ≤1px even-width
+                                    // adjustment).
+                                    if css_w > 100
+                                        && css_h > 100
+                                        && settled_w >= 640
+                                        && settled_h >= 480
+                                        && (settled_w.abs_diff(server_w) > 4
+                                            || settled_h.abs_diff(server_h) > 4)
+                                    {
+                                        // Keep the stored config in sync
+                                        let current_config = config.borrow().clone();
+                                        if let Some(mut c) = current_config {
+                                            c = c.with_resolution(settled_w, settled_h);
+                                            *config.borrow_mut() = Some(c);
+                                        }
+
+                                        if let Some(ref sender) = *ironrdp_tx.borrow() {
+                                            #[expect(
+                                                clippy::cast_possible_truncation,
+                                                reason = "RDP resolution is clamped well below u16::MAX in this code path"
+                                            )]
+                                            let sw = settled_w as u16;
+                                            #[expect(
+                                                clippy::cast_possible_truncation,
+                                                reason = "RDP resolution is clamped well below u16::MAX in this code path"
+                                            )]
+                                            let sh = settled_h as u16;
+                                            let _ = sender.send(RdpClientCommand::SetDesktopSize {
+                                                width: sw,
+                                                height: sh,
+                                            });
+                                        }
+
+                                        tracing::info!(
+                                            protocol = "rdp",
+                                            server_w,
+                                            server_h,
+                                            settled_w,
+                                            settled_h,
+                                            "[RDP] Snapping desktop to settled drawing-area size (toolbar layout)"
+                                        );
+                                    }
                                 }
 
                                 // Phase 3: Monitor local clipboard changes and

--- a/rustconn/src/embedded_rdp/drawing.rs
+++ b/rustconn/src/embedded_rdp/drawing.rs
@@ -86,7 +86,17 @@ impl super::EmbeddedRdpWidget {
                         let css_buf_h = f64::from(buf_height) / effective_scale;
                         let scale_x = f64::from(width) / css_buf_w;
                         let scale_y = f64::from(height) / css_buf_h;
-                        let scale = scale_x.min(scale_y);
+                        // Within a pixel or two of the drawing area (the ≤1px
+                        // even-width residual): blit 1:1 for a sharp border instead of
+                        // a sub-pixel rescale. Larger mismatches (a resize in flight)
+                        // still scale-to-fit with aspect preserved.
+                        let scale = if (css_buf_w - f64::from(width)).abs() <= 4.0
+                            && (css_buf_h - f64::from(height)).abs() <= 4.0
+                        {
+                            1.0
+                        } else {
+                            scale_x.min(scale_y)
+                        };
 
                         // Center the image
                         let offset_x = css_buf_w.mul_add(-scale, f64::from(width)) / 2.0;
@@ -146,7 +156,17 @@ impl super::EmbeddedRdpWidget {
                         let css_buf_h = f64::from(buf_height) / effective_scale;
                         let scale_x = f64::from(width) / css_buf_w;
                         let scale_y = f64::from(height) / css_buf_h;
-                        let scale = scale_x.min(scale_y);
+                        // Within a pixel or two of the drawing area (the ≤1px
+                        // even-width residual): blit 1:1 for a sharp border instead of
+                        // a sub-pixel rescale. Larger mismatches (a resize in flight)
+                        // still scale-to-fit with aspect preserved.
+                        let scale = if (css_buf_w - f64::from(width)).abs() <= 4.0
+                            && (css_buf_h - f64::from(height)).abs() <= 4.0
+                        {
+                            1.0
+                        } else {
+                            scale_x.min(scale_y)
+                        };
 
                         let offset_x = css_buf_w.mul_add(-scale, f64::from(width)) / 2.0;
                         let offset_y = css_buf_h.mul_add(-scale, f64::from(height)) / 2.0;

--- a/rustconn/src/embedded_rdp/resize.rs
+++ b/rustconn/src/embedded_rdp/resize.rs
@@ -134,9 +134,10 @@ impl super::EmbeddedRdpWidget {
                         let h_diff = (device_height as i32 - current_rdp_h as i32).unsigned_abs();
 
                         if w_diff > RESIZE_THRESHOLD_PX || h_diff > RESIZE_THRESHOLD_PX {
-                            // Round down to multiple of 4 for RDP compatibility
-                            let rounded_width = (device_width / 4) * 4;
-                            let rounded_height = (device_height / 4) * 4;
+                            // Request the exact device size.
+                            // Width must be even (MS-RDPEDISP); height is used as-is.
+                            let rounded_width = device_width & !1;
+                            let rounded_height = device_height;
 
                             // Guard against degenerate sizes (widget mid-layout
                             // or collapsed): never request a sub-640x480 desktop,
@@ -322,9 +323,10 @@ impl super::EmbeddedRdpWidget {
         )]
         let device_height = (f64::from(css_height) * effective_scale) as u32;
 
-        // Round down to a multiple of 4 for RDP codec compatibility
-        let rounded_width = (device_width / 4) * 4;
-        let rounded_height = (device_height / 4) * 4;
+        // Request the exact device size — RDP takes any resolution. Width must be
+        // even (MS-RDPEDISP hard requirement); height is used as-is.
+        let rounded_width = device_width & !1;
+        let rounded_height = device_height;
         if rounded_width < 640 || rounded_height < 480 {
             // Widget not laid out yet — nothing sensible to request
             return;


### PR DESCRIPTION
Right now the RDP connection screen size does not account for the toolbar's height, resulting in black bars left and right, as well as a blurry image from downscaling. 

This change accounts for the toolbar height, as well as using the full size available **without** downscaling and blurry image for the user. 