### PR TITLE
Fixed RDP display scaling issue

### DIFF
--- a/rustconn-core/src/rdp_client/client/commands.rs
+++ b/rustconn-core/src/rdp_client/client/commands.rs
@@ -80,10 +80,17 @@ pub async fn process_command<W: FramedWrite>(
                 send_input_events(active_stage, image, writer, &[event]).await;
             }
         }
-        RdpClientCommand::SetDesktopSize { width, height } => {
-            if let Some(result) =
-                active_stage.encode_resize(u32::from(width), u32::from(height), None, None)
-            {
+        RdpClientCommand::SetDesktopSize {
+            width,
+            height,
+            scale_percent,
+        } => {
+            if let Some(result) = active_stage.encode_resize(
+                u32::from(width),
+                u32::from(height),
+                scale_percent,
+                None,
+            ) {
                 match result {
                     Ok(frame) => {
                         let _ = writer.write_all(&frame).await;

--- a/rustconn-core/src/rdp_client/client/mod.rs
+++ b/rustconn-core/src/rdp_client/client/mod.rs
@@ -181,11 +181,24 @@ impl RdpClient {
 
     /// Requests a desktop size change.
     ///
+    /// `scale_percent` is the desktop scale factor as a percentage (e.g. `200`
+    /// for 200%) forwarded to the server; `None` leaves it at the server default
+    /// of 100%.
+    ///
     /// # Errors
     ///
     /// Returns error if not connected or channel is closed.
-    pub fn set_desktop_size(&self, width: u16, height: u16) -> Result<(), RdpClientError> {
-        self.send_command(RdpClientCommand::SetDesktopSize { width, height })
+    pub fn set_desktop_size(
+        &self,
+        width: u16,
+        height: u16,
+        scale_percent: Option<u32>,
+    ) -> Result<(), RdpClientError> {
+        self.send_command(RdpClientCommand::SetDesktopSize {
+            width,
+            height,
+            scale_percent,
+        })
     }
 
     /// Disconnects from the RDP server and cleans up resources

--- a/rustconn-core/src/rdp_client/event.rs
+++ b/rustconn-core/src/rdp_client/event.rs
@@ -684,6 +684,10 @@ pub enum RdpClientCommand {
         width: u16,
         /// Desired height
         height: u16,
+        /// Desktop scale factor as a percentage (e.g. `200` for 200%), forwarded
+        /// to the server in the MS-RDPEDISP monitor layout. `None` leaves the
+        /// scale factor unset, which the server interprets as 100%.
+        scale_percent: Option<u32>,
     },
 
     /// Send Ctrl+Alt+Del key sequence

--- a/rustconn/src/embedded_rdp/connection.rs
+++ b/rustconn/src/embedded_rdp/connection.rs
@@ -334,12 +334,7 @@ impl super::EmbeddedRdpWidget {
         // Compute RDP desktop scale factor as percentage (e.g. 2.0 → 200)
         // This tells the Windows server what DPI scaling to use so UI elements
         // appear at the correct logical size on HiDPI displays.
-        #[expect(
-            clippy::cast_possible_truncation,
-            clippy::cast_sign_loss,
-            reason = "value range fits the target type and is non-negative by construction in this code path"
-        )]
-        let rdp_scale_percent = (effective_scale * 100.0) as u32;
+        let rdp_scale_percent = super::rdp_scale_percent(effective_scale);
 
         tracing::debug!(
             protocol = "rdp",
@@ -615,6 +610,7 @@ impl super::EmbeddedRdpWidget {
                         let _ = sender.send(RdpClientCommand::SetDesktopSize {
                             width: sw,
                             height: sh,
+                            scale_percent: Some(super::rdp_scale_percent(effective_scale)),
                         });
                     }
                     tracing::info!(
@@ -633,7 +629,8 @@ impl super::EmbeddedRdpWidget {
         // connection path sets the state directly and never calls set_state (#185).
         let jiggler = self.jiggler_handles();
 
-        // Capture effective scale for cursor size correction
+        // Server cursors arrive at the session DPI (== our display scale); the
+        // handler downscales device→logical px for GDK using this factor.
         let cursor_scale = effective_scale;
 
         // Capture local cursor visibility preference
@@ -1649,7 +1646,10 @@ impl super::EmbeddedRdpWidget {
     ) {
         use gtk4::gdk;
 
-        let expected = usize::from(width) * usize::from(height) * 4;
+        let bpp = 4;
+        let w = usize::from(width);
+        let h = usize::from(height);
+        let expected = w * h * bpp;
         if data.len() < expected {
             tracing::warn!(
                 expected,
@@ -1659,125 +1659,111 @@ impl super::EmbeddedRdpWidget {
             return;
         }
 
-        // Crop transparent padding from bottom and right edges.
-        // Windows cursors are padded to 32×32 or 64×64 but the visible
-        // content is smaller. The transparent padding can cause rendering
-        // artifacts on some Wayland compositors after downscaling.
-        let w = usize::from(width);
-        let h = usize::from(height);
-        let bpp = 4;
+        // The server renders the pointer at the session DPI, which now matches
+        // our display scale — so a 200% session sends a 2× (device-pixel)
+        // cursor bitmap. GDK interprets a cursor texture's dimensions as
+        // *logical* pixels (there is no HiDPI/scale hint on `from_texture`), so
+        // handing it the raw device bitmap yields a cursor ~`scale`× too large.
+        // We therefore downscale device→logical here.
+        //
+        // The downscale is an area-average (box filter), NOT nearest-neighbor:
+        // NN samples one source pixel per destination pixel and drops the rest,
+        // which erased the thin 1px strokes of HiDPI cursors (the "half missing"
+        // pointer). Averaging every covered source pixel preserves them.
+        //
+        // The logical-size texture is mildly soft: the compositor upscales it
+        // back to device resolution for the pointer's monitor. GTK 4.14 has no
+        // way to pass a scaled cursor buffer. When built against GTK ≥ 4.16
+        // (e.g. the Flatpak runtime), `gdk_cursor_new_from_callback` would let
+        // us hand back the full-resolution bitmap plus its scale for a crisp
+        // HiDPI cursor with no downscale.
+        // TODO: add a v4_16-gated `from_callback` path for a crisp cursor.
+        let scale = cursor_scale.max(1.0);
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "cursor dimensions are small and non-negative; logical size fits usize"
+        )]
+        let dst_w = ((w as f64 / scale).round() as usize).max(1);
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "cursor dimensions are small and non-negative; logical size fits usize"
+        )]
+        let dst_h = ((h as f64 / scale).round() as usize).max(1);
 
-        // Find last row with any non-transparent pixel
-        let crop_h = (0..h)
-            .rev()
-            .find(|&row| {
-                let base = row * w * bpp;
-                (0..w).any(|col| data[base + col * bpp + 3] != 0)
-            })
-            .map_or(1, |row| row + 1);
-
-        // Find last column with any non-transparent pixel
-        let crop_w = (0..w)
-            .rev()
-            .find(|&col| (0..crop_h).any(|row| data[row * w * bpp + col * bpp + 3] != 0))
-            .map_or(1, |col| col + 1);
-
-        // Build cropped RGBA buffer
-        let cropped_size = crop_w * crop_h * bpp;
-        let mut cropped = Vec::with_capacity(cropped_size);
-        for row in 0..crop_h {
-            let src_start = row * w * bpp;
-            let src_end = src_start + crop_w * bpp;
-            cropped.extend_from_slice(&data[src_start..src_end]);
-        }
-
-        let scale = cursor_scale;
-        if scale > 1.01 {
+        // Contiguous source spans: sx1 of column N equals sx0 of column N+1, so
+        // every source pixel contributes to exactly one destination pixel.
+        let span = |d: usize, src_max: usize| {
             #[expect(
                 clippy::cast_possible_truncation,
                 clippy::cast_sign_loss,
-                reason = "value range fits the target type and is non-negative by construction in this code path"
+                reason = "cursor dimensions are small and non-negative; span fits usize"
             )]
-            let logical_w = (crop_w as f64 / scale).round().max(1.0) as u16;
+            let lo = ((d as f64) * scale).round() as usize;
             #[expect(
                 clippy::cast_possible_truncation,
                 clippy::cast_sign_loss,
-                reason = "value range fits the target type and is non-negative by construction in this code path"
+                reason = "cursor dimensions are small and non-negative; span fits usize"
             )]
-            let logical_h = (crop_h as f64 / scale).round().max(1.0) as u16;
-            let hotspot_logical_x = (f64::from(hotspot_x) / scale).round() as i32;
-            let hotspot_logical_y = (f64::from(hotspot_y) / scale).round() as i32;
+            let hi = (((d + 1) as f64) * scale).round() as usize;
+            (lo.min(src_max), hi.min(src_max).max(lo + 1).min(src_max))
+        };
 
-            let src_w = crop_w;
-            let dst_w = usize::from(logical_w);
-            let dst_h = usize::from(logical_h);
-
-            // Nearest-neighbor downscale with premultiplied alpha + R↔B swap
-            let mut scaled = vec![0u8; dst_w * dst_h * bpp];
-            for dy in 0..dst_h {
-                #[expect(
-                    clippy::cast_possible_truncation,
-                    clippy::cast_sign_loss,
-                    reason = "value range fits the target type and is non-negative by construction in this code path"
-                )]
-                let sy = (dy as f64 * scale) as usize;
-                for dx in 0..dst_w {
-                    #[expect(
-                        clippy::cast_possible_truncation,
-                        clippy::cast_sign_loss,
-                        reason = "value range fits the target type and is non-negative by construction in this code path"
-                    )]
-                    let sx = (dx as f64 * scale) as usize;
-                    let src_off = (sy * src_w + sx) * bpp;
-                    let dst_off = (dy * dst_w + dx) * bpp;
-                    if src_off + 4 <= cropped.len() {
-                        let a = u16::from(cropped[src_off + 3]);
-                        if a == 0 {
-                            // transparent — [0,0,0,0]
-                        } else if a == 255 {
-                            scaled[dst_off] = cropped[src_off + 2]; // B
-                            scaled[dst_off + 1] = cropped[src_off + 1]; // G
-                            scaled[dst_off + 2] = cropped[src_off]; // R
-                            scaled[dst_off + 3] = 255;
-                        } else {
-                            scaled[dst_off] = (u16::from(cropped[src_off + 2]) * a / 255) as u8;
-                            scaled[dst_off + 1] = (u16::from(cropped[src_off + 1]) * a / 255) as u8;
-                            scaled[dst_off + 2] = (u16::from(cropped[src_off]) * a / 255) as u8;
-                            scaled[dst_off + 3] = cropped[src_off + 3];
-                        }
+        // Output is B8g8r8a8 premultiplied: server data is straight-alpha RGBA,
+        // so we premultiply before averaging (correct edge blending) and swap
+        // R↔B on write.
+        let mut out = vec![0u8; dst_w * dst_h * bpp];
+        for dy in 0..dst_h {
+            let (sy0, sy1) = span(dy, h);
+            for dx in 0..dst_w {
+                let (sx0, sx1) = span(dx, w);
+                let (mut acc_r, mut acc_g, mut acc_b, mut acc_a, mut count) =
+                    (0u32, 0u32, 0u32, 0u32, 0u32);
+                for sy in sy0..sy1 {
+                    for sx in sx0..sx1 {
+                        let o = (sy * w + sx) * bpp;
+                        let a = u32::from(data[o + 3]);
+                        acc_r += u32::from(data[o]) * a / 255;
+                        acc_g += u32::from(data[o + 1]) * a / 255;
+                        acc_b += u32::from(data[o + 2]) * a / 255;
+                        acc_a += a;
+                        count += 1;
                     }
                 }
+                let count = count.max(1);
+                let d = (dy * dst_w + dx) * bpp;
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "averaged 8-bit channel stays within u8"
+                )]
+                {
+                    out[d] = (acc_b / count) as u8; // B
+                    out[d + 1] = (acc_g / count) as u8; // G
+                    out[d + 2] = (acc_r / count) as u8; // R
+                    out[d + 3] = (acc_a / count) as u8; // A
+                }
             }
-
-            let bytes = glib::Bytes::from(&scaled);
-            let texture = gdk::MemoryTexture::new(
-                i32::from(logical_w),
-                i32::from(logical_h),
-                gdk::MemoryFormat::B8g8r8a8Premultiplied,
-                &bytes,
-                usize::from(logical_w) * bpp,
-            );
-            let cursor =
-                gdk::Cursor::from_texture(&texture, hotspot_logical_x, hotspot_logical_y, None);
-            drawing_area.set_cursor(Some(&cursor));
-        } else {
-            // 1x display — no scaling, use cropped RGBA directly
-            let bytes = glib::Bytes::from(&cropped);
-            let texture = gdk::MemoryTexture::new(
-                crop_w as i32,
-                crop_h as i32,
-                gdk::MemoryFormat::R8g8b8a8,
-                &bytes,
-                crop_w * bpp,
-            );
-            let cursor = gdk::Cursor::from_texture(
-                &texture,
-                i32::from(hotspot_x),
-                i32::from(hotspot_y),
-                None,
-            );
-            drawing_area.set_cursor(Some(&cursor));
         }
+
+        let hotspot_logical_x = (f64::from(hotspot_x) / scale).round() as i32;
+        let hotspot_logical_y = (f64::from(hotspot_y) / scale).round() as i32;
+
+        let bytes = glib::Bytes::from(&out);
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::cast_possible_wrap,
+            reason = "logical cursor dimensions are small and fit i32/i32 texture args"
+        )]
+        let texture = gdk::MemoryTexture::new(
+            dst_w as i32,
+            dst_h as i32,
+            gdk::MemoryFormat::B8g8r8a8Premultiplied,
+            &bytes,
+            dst_w * bpp,
+        );
+        let cursor = gdk::Cursor::from_texture(&texture, hotspot_logical_x, hotspot_logical_y, None);
+        drawing_area.set_cursor(Some(&cursor));
     }
 
     /// Fallback when rdp-embedded feature is not enabled

--- a/rustconn/src/embedded_rdp/mod.rs
+++ b/rustconn/src/embedded_rdp/mod.rs
@@ -127,6 +127,20 @@ const fn round_rdp_desktop(width: u32, height: u32) -> (u32, u32) {
     )
 }
 
+/// Converts an effective display scale (e.g. `2.0`) into the RDP desktop scale
+/// factor percentage (e.g. `200`) forwarded to the server in a Display Control
+/// monitor layout. Mirrors the initial-connect computation so a dynamic resize
+/// keeps the same server-side DPI the user selected.
+#[cfg(feature = "rdp-embedded")]
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "effective scale is a small positive multiplier; the percentage fits u32"
+)]
+fn rdp_scale_percent(effective_scale: f64) -> u32 {
+    (effective_scale * 100.0) as u32
+}
+
 /// Launches `command` through the Windows Run dialog, layout-independently.
 ///
 /// Opens Run with the Win+R scancode hotkey, types `command` via Unicode

--- a/rustconn/src/embedded_rdp/resize.rs
+++ b/rustconn/src/embedded_rdp/resize.rs
@@ -164,6 +164,9 @@ impl super::EmbeddedRdpWidget {
                                     let _ = sender.send(RdpClientCommand::SetDesktopSize {
                                         width: w,
                                         height: h,
+                                        scale_percent: Some(super::rdp_scale_percent(
+                                            effective_scale,
+                                        )),
                                     });
                                 }
 
@@ -360,6 +363,7 @@ impl super::EmbeddedRdpWidget {
                 let _ = sender.send(RdpClientCommand::SetDesktopSize {
                     width: w,
                     height: h,
+                    scale_percent: Some(super::rdp_scale_percent(effective_scale)),
                 });
             }
 


### PR DESCRIPTION
Fixed a problem with RDP connections not sending the correct display scaling setting to the RDP server, resulting in 100% scaled RDP connections on e.g. 200% scaled screens (very small). This is a problem introduced with the last PR about RDP connections not using the full available screen space. Since I did not have a proper 5k screen to test available yesterday, this did not come up as a problem.  

Now tested on a 5k screen with 200% scaling = RDP connection with nice crisp 200% scaling. 100% scaled laptop screen tested as well, results in 100% scale on RDP. 

Let me know if this needs any further testing, maybe also check on your end, it is absolutely not my intention to introduce new bugs to the project, sorry about this. 

Thanks