### PR TITLE
headless core-cli cleanup

### DIFF
--- a/.kiro/steering/project-rules.md
+++ b/.kiro/steering/project-rules.md
@@ -10,10 +10,17 @@ Communication language: Ukrainian.
 
 | Crate | Purpose | Restrictions |
 |-------|---------|-------------|
-| `rustconn-core` | Business logic, models, protocols | **FORBIDDEN**: gtk4, adw, vte4 |
-| `rustconn-cli` | CLI interface | Only rustconn-core |
-| `rustconn` | GTK4/libadwaita GUI | May import everything |
+| `rustconn-core` | Domain logic: models, config, CRUD managers, import/export, protocol data, credential abstractions | **FORBIDDEN**: gtk4, adw, vte4. Default features stay headless/empty. Embedded clients, GFX, RD Gateway, and host keyring are optional features only. |
+| `rustconn-cli` | Headless management over core data | Only rustconn-core. Default features stay minimal; client launch and secret-management paths are optional. |
+| `rustconn` | GTK4/libadwaita GUI, dialogs, embedded/external session presentation | May import GUI crates and enable core integration features |
 | `rustconn-pty-sys` | Isolated FFI helper (macOS PTY controlling terminal, `setsid`+`TIOCSCTTY`) | **Only** sanctioned `unsafe` location (M-UNSAFE); `libc` only, no gtk4/adw/vte4 |
+
+### Codex Target Split
+
+- Core ticket → start in `rustconn-core/src/lib.rs`, `models`, `config`, `connection`, `protocol`, `secret`; keep runtime integrations behind features.
+- CLI ticket → start in `rustconn-cli/src/cli.rs`, `commands`, `error.rs`; keep the default path to config/CRUD/list/import/export/simple operations.
+- GUI ticket → start in `rustconn/src/dialogs`, `window`, `embedded_*`; do not move GTK/libadwaita concepts into core or CLI.
+- Cross-layer work must name the boundary being crossed and keep each layer's change reviewable on its own.
 
 ## Code Philosophy (YAGNI / lazy-senior)
 

--- a/.kiro/steering/protocol-guide.md
+++ b/.kiro/steering/protocol-guide.md
@@ -10,6 +10,9 @@ You are editing a file in `rustconn-core/src/protocol/`.
 ## Crate Boundary
 
 This crate is GUI-free. FORBIDDEN: `gtk4`, `adw`, `vte4`, `libadwaita`.
+Keep protocol model/validation/argument-building in core. Put embedded runtime
+clients behind explicit core features, CLI launch behavior behind CLI features,
+and GTK dialogs/session presentation in `rustconn/`.
 
 ## New Protocol — Checklist
 
@@ -17,8 +20,8 @@ This crate is GUI-free. FORBIDDEN: `gtk4`, `adw`, `vte4`, `libadwaita`.
 2. Define `capabilities` (has_terminal, has_password, has_port, etc.)
 3. Set `default_port`
 4. Implement `Protocol` trait
-5. Add CLI handler in `rustconn-cli`
-6. Add dialog in `rustconn/src/dialogs/connection/`
+5. Add headless CLI CRUD flags in `rustconn-cli`; gate launch-only behavior if needed
+6. Add dialog/session UI in `rustconn/src/dialogs/connection/` and `rustconn/src/window/`
 7. Update sidebar filter icons if needed
 
 ## Errors

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ More screenshots on the [Flathub listing](https://flathub.org/apps/io.github.tot
 | **Automation** | Expect rules, key sequences, pre/post-connect tasks, cluster & ad-hoc broadcast, session reconnect, Wake-on-LAN |
 | **Workflow** | Smart folders, SSH port forwarding, visual SSH tunnel builder, workspace profiles (save/restore open sessions), settings backup/restore, .rdp file association |
 | **Cloud Sync** | Synchronize connections via shared cloud directory (Google Drive, Syncthing, Nextcloud, Dropbox); group sync with Master/Import access model; simple sync with UUID-based merge |
-| **CLI** | `rustconn-cli` — headless management: list/add/update/delete connections, import/export, snippets, groups, templates, clusters, secrets, WoL, shell completions |
+| **CLI** | `rustconn-cli` — headless management: list/add/update/delete connections, import/export, snippets, groups, templates, clusters, WoL, shell completions; optional secret and client-launch commands behind features |
 | **Languages** | English + 16 translations (Belarusian, Czech, Danish, German, Spanish, French, Italian, Kazakh, Dutch, Polish, Portuguese, Slovak, Swedish, Ukrainian, Uzbek, Chinese) |
 
 ### Protocol support

--- a/docs/AI_DEVELOPMENT.md
+++ b/docs/AI_DEVELOPMENT.md
@@ -124,6 +124,21 @@ is the canonical source.
 
 ## Design Decisions
 
+### Codex target boundaries
+
+Keep future AI tasks sliced by crate boundary:
+
+| Target | Scope | First files to inspect |
+|--------|-------|------------------------|
+| Core | Domain logic, models, config persistence, import/export, protocol data, credential abstractions | `rustconn-core/src/lib.rs`, `rustconn-core/src/models`, `rustconn-core/src/config`, `rustconn-core/src/connection`, `rustconn-core/src/protocol` |
+| CLI | Headless management over core data: list/show/add/update/delete, import/export, tests, tags/groups/templates | `rustconn-cli/src/cli.rs`, `rustconn-cli/src/commands`, `rustconn-cli/src/error.rs` |
+| GUI | GTK/libadwaita presentation, dialogs, embedded/external sessions, toasts, window state | `rustconn/src/dialogs`, `rustconn/src/window`, `rustconn/src/embedded_*` |
+
+Do not mix these in one Codex ticket unless the change is an end-to-end feature
+that explicitly requires all layers. `rustconn-core` has an empty default
+feature set; embedded clients, RD Gateway/GFX, host keyring support, and CLI
+client-launch behavior are optional integration features.
+
 ### Steering vs hooks
 
 Steering provides the *mental model* (what conventions exist and why); hooks

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,12 +33,44 @@ rustconn-pty-sys/   # Isolated FFI helper (macOS PTY controlling terminal)
 
 | Crate | Purpose | Allowed Dependencies |
 |-------|---------|---------------------|
-| `rustconn-core` | Business logic, protocols, credentials, import/export | `tokio`, `serde`, `secrecy`, `thiserror` — NO GTK |
-| `rustconn` | GTK4 UI, dialogs, terminal integration | `gtk4`, `vte4`, `libadwaita`, `rustconn-core`, `rustconn-pty-sys` |
-| `rustconn-cli` | CLI interface | `clap`, `rustconn-core` — NO GTK |
+| `rustconn-core` | Domain logic: models, config persistence, CRUD managers, protocol data, import/export, credential abstractions | `tokio`, `serde`, `secrecy`, `thiserror` — NO GTK |
+| `rustconn` | GTK4 UI, dialogs, terminal integration, embedded/external session presentation | `gtk4`, `vte4`, `libadwaita`, `rustconn-core`, `rustconn-pty-sys` |
+| `rustconn-cli` | Headless management CLI: config, connections, import/export, list/show, simple operations | `clap`, `rustconn-core` — NO GTK |
 | `rustconn-pty-sys` | FFI helper: give a spawned child its PTY slave as a controlling terminal (`setsid` + `TIOCSCTTY`) for the macOS native PTY ([#175](https://github.com/totoshko88/RustConn/issues/175)) | `libc` only — NO GTK |
 
 **Decision Rule:** "Does this code need GTK widgets?" → No → `rustconn-core` / Yes → `rustconn`
+
+### Headless Boundary
+
+`rustconn-core` defaults to an empty feature set. A minimal build is the shared
+domain kernel and must not pull GUI, DBus/keyring, embedded-client, GFX, or RD
+Gateway runtime dependencies by default.
+
+Optional integration features:
+
+| Feature | Owner | Purpose |
+|---------|-------|---------|
+| `rustconn-core/system-keyring` | GUI / full CLI | Host keyring integration (`oo7` or macOS Keychain) |
+| `rustconn-core/vnc-embedded` | GUI | Native VNC client runtime |
+| `rustconn-core/rdp-embedded` | GUI | Native IronRDP client runtime |
+| `rustconn-core/gfx-h264` | GUI | RDP EGFX/H.264 pipeline |
+| `rustconn-core/rd-gateway` | GUI | Native RD Gateway tunneling for embedded RDP |
+| `rustconn-cli/client-launch` | Full CLI | Launch external clients or desktop file managers |
+| `rustconn-cli/secret-management` | Full CLI | Secret backend commands and system keyring support |
+
+Default edit targets:
+
+| Change | Start here | Do not start here |
+|--------|------------|-------------------|
+| Connection fields, validation, serialization | `rustconn-core/src/models`, `rustconn-core/src/connection`, `rustconn-core/src/protocol` | `rustconn/src/dialogs` |
+| Headless CRUD/list/import/export behavior | `rustconn-cli/src/commands`, `rustconn-core/src/config`, `rustconn-core/src/import`, `rustconn-core/src/export` | `rustconn/src/window` |
+| Embedded RDP/VNC runtime behavior | `rustconn-core/src/rdp_client`, `rustconn-core/src/vnc_client`, then `rustconn/src/embedded_*` | Generic core managers |
+| GUI dialogs, session widgets, toasts | `rustconn/src/dialogs`, `rustconn/src/window`, `rustconn/src/embedded_*` | `rustconn-core` |
+| Secret storage model | `rustconn-core/src/secret` | GUI settings pages, unless only presentation changes |
+
+Keep desktop/client integration behind explicit features or in `rustconn/`.
+Core may expose data types and pure builders for those integrations, but should
+not require their runtime dependencies in the default feature set.
 
 ### The `unsafe` Exception
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,11 +31,11 @@ rustconn-pty-sys/   # Isolated FFI helper (macOS PTY controlling terminal)
 
 ### Crate Boundaries
 
-| Crate | Purpose | Allowed Dependencies |
+| Crate | Purpose | Dependency Boundary |
 |-------|---------|---------------------|
-| `rustconn-core` | Domain logic: models, config persistence, CRUD managers, protocol data, import/export, credential abstractions | `tokio`, `serde`, `secrecy`, `thiserror` — NO GTK |
-| `rustconn` | GTK4 UI, dialogs, terminal integration, embedded/external session presentation | `gtk4`, `vte4`, `libadwaita`, `rustconn-core`, `rustconn-pty-sys` |
-| `rustconn-cli` | Headless management CLI: config, connections, import/export, list/show, simple operations | `clap`, `rustconn-core` — NO GTK |
+| `rustconn-core` | Domain logic: models, config persistence, CRUD managers, protocol data, import/export, credential abstractions | Non-GUI Rust dependencies only; host keyring and embedded-client runtimes stay behind explicit features — NO GTK |
+| `rustconn` | GTK4 UI, dialogs, terminal integration, embedded/external session presentation | Owns `gtk4`, `vte4`, `libadwaita`, and enables core integration features when needed |
+| `rustconn-cli` | Headless management CLI: config, connections, import/export, list/show, simple operations | CLI/runtime dependencies plus `rustconn-core`; client launch and secret-management stay behind explicit features — NO GTK |
 | `rustconn-pty-sys` | FFI helper: give a spawned child its PTY slave as a controlling terminal (`setsid` + `TIOCSCTTY`) for the macOS native PTY ([#175](https://github.com/totoshko88/RustConn/issues/175)) | `libc` only — NO GTK |
 
 **Decision Rule:** "Does this code need GTK widgets?" → No → `rustconn-core` / Yes → `rustconn`
@@ -633,19 +633,27 @@ pub trait SecretBackend: Send + Sync {
 ```
 
 **Implementations:**
-- `LibsecretBackend`: GNOME Keyring (default)
+- `LibsecretBackend`: Secret Service via `oo7` when `system-keyring` is enabled on non-macOS
+- `MacOsKeychainBackend`: macOS Keychain when `system-keyring` is enabled on macOS
 - `KdbxExporter` + `kdbx_keyring`: KeePassXC/KeePass via direct `.kdbx` file access
 - `BitwardenBackend`: Bitwarden via CLI
 - `OnePasswordBackend`: 1Password via CLI
 - `PassboltBackend`: Passbolt via CLI (`go-passbolt-cli`)
 - `PassBackend`: Pass (passwordstore.org) via `pass` CLI
 
-### System Keyring Integration
+### Optional System Keyring Integration
 
-The `keyring` module (`rustconn-core/src/secret/keyring.rs`) provides shared keyring storage via `secret-tool` (libsecret Secret Service API) for all backends that need system keyring integration:
+The `keyring` module (`rustconn-core/src/secret/keyring.rs`) provides shared
+keyring storage for backends that need host keyring integration. It is active
+only when `rustconn-core/system-keyring` is enabled; otherwise the same public
+async functions compile as unavailable stubs so headless builds do not pull
+desktop/keyring dependencies.
+
+On Linux/BSD this talks to the Secret Service in process via `oo7`. On macOS,
+credentials route to the native Keychain backend.
 
 ```rust
-// Check if secret-tool is available
+// Check if host keyring integration is available
 if keyring::is_secret_tool_available().await {
     // Store a credential
     keyring::store("bitwarden-master", &password, "Bitwarden Master Password").await?;
@@ -670,7 +678,9 @@ On settings load, backends with "Save to system keyring" enabled automatically r
 
 #### Flatpak Compatibility
 
-The `secret-tool` binary is not included in the GNOME Flatpak runtime (`org.gnome.Platform`). To ensure keyring operations work inside the Flatpak sandbox, `libsecret` 0.21.7 is built as a Flatpak module in all manifests. This provides the `secret-tool` binary at `/app/bin/secret-tool`. The D-Bus permission `--talk-name=org.freedesktop.secrets` is already present in `finish-args`, allowing `secret-tool` to communicate with GNOME Keyring / KDE Wallet from within the sandbox.
+Flatpak keyring access uses the same Secret Service D-Bus permission
+(`--talk-name=org.freedesktop.secrets`). No `secret-tool` runtime binary is
+required for the Linux/BSD path because the `oo7` client runs in process.
 
 ### KeePass Hierarchical Storage
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -65,8 +65,12 @@ Binary: `target/debug/rustconn` or `target/release/rustconn`.
 ### CLI (`rustconn-cli`)
 
 ```bash
+# Minimal/headless build
 cargo build -p rustconn-cli
 cargo build --release -p rustconn-cli
+
+# Full CLI with desktop/client-launch and secret-management commands
+cargo build -p rustconn-cli --features full
 ```
 
 Binary: `target/debug/rustconn-cli` or `target/release/rustconn-cli`.
@@ -93,10 +97,13 @@ cargo build --release      # release, all crates
 | Flag | Default | Description |
 |------|:-------:|-------------|
 | `tray` | ✓ | System tray icon (ksni + resvg) |
+| `system-keyring` | ✓ | Host keyring integration via `rustconn-core/system-keyring` |
 | `vnc-embedded` | ✓ | Embedded VNC client (vnc-rs) |
 | `rdp-embedded` | ✓ | Embedded RDP client (IronRDP) |
 | `rdp-audio` | ✓ | RDP session audio (cpal); enables `rdp-embedded` |
+| `rd-gateway` | ✓ | Native RD Gateway tunneling for embedded RDP |
 | `wayland-native` | ✓ | Wayland surface support (gdk4-wayland) |
+| `tray-macos` | — | macOS tray icon support |
 | `adw-1-6` | — | libadwaita 1.6+ (AdwSpinner, CSS variables) |
 | `adw-1-7` | — | libadwaita 1.7+ (AdwWrapBox); enables `adw-1-6` |
 | `adw-1-8` | — | libadwaita 1.8+ (AdwShortcutsDialog); enables `adw-1-7` |
@@ -119,10 +126,50 @@ cargo build --release -p rustconn --features adw-1-7
 
 ### rustconn-core (library)
 
+`rustconn-core` defaults to a headless domain kernel (`default = []`). Enable
+integration features only from crates that need host keyrings or embedded
+client runtimes.
+
 | Flag | Default | Description |
 |------|:-------:|-------------|
-| `vnc-embedded` | ✓ | vnc-rs |
-| `rdp-embedded` | ✓ | IronRDP |
+| `system-keyring` | — | Host keyring integration (`oo7` on Linux/BSD, macOS Keychain on macOS) |
+| `vnc-embedded` | — | vnc-rs runtime for embedded VNC sessions |
+| `rdp-embedded` | — | IronRDP runtime for embedded RDP sessions |
+| `gfx-h264` | — | RDP EGFX/H.264 pipeline; enables `rdp-embedded` |
+| `rd-gateway` | — | Native RD Gateway tunneling; enables `rdp-embedded` |
+
+Examples:
+
+```bash
+# Headless domain kernel
+cargo build -p rustconn-core --no-default-features
+
+# Core with embedded clients and system keyring integration
+cargo build -p rustconn-core --no-default-features \
+  --features "system-keyring vnc-embedded rdp-embedded rd-gateway"
+```
+
+### rustconn-cli
+
+`rustconn-cli` defaults to the minimal headless management path. Desktop-adjacent
+commands are opt-in.
+
+| Flag | Default | Description |
+|------|:-------:|-------------|
+| `client-launch` | — | External client/file-manager launch commands such as `connect` |
+| `secret-management` | — | `secret` subcommands and `rustconn-core/system-keyring` |
+| `desktop-integration` | — | Convenience group: `client-launch` + `secret-management` |
+| `full` | — | Full CLI feature set; currently enables `desktop-integration` |
+
+Examples:
+
+```bash
+# Minimal/headless CLI
+cargo build -p rustconn-cli --no-default-features
+
+# Full CLI including optional desktop/client-launch paths
+cargo build -p rustconn-cli --features full
+```
 
 ---
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -1,8 +1,8 @@
 # RustConn CLI Reference
 
-**Version 0.18.2** | Full command-line interface for RustConn connection management
+**Version 0.18.6** | Command-line interface for RustConn connection management
 
-The `rustconn-cli` binary provides full connection management from the terminal. It shares the same configuration files as the GUI (`~/.config/rustconn/`), so changes made in either tool are immediately visible to the other.
+The `rustconn-cli` binary provides headless connection management from the terminal. It shares the same configuration files as the GUI (`~/.config/rustconn/`), so changes made in either tool are immediately visible to the other. The default build is the minimal headless path; desktop/client-launch and secret-management commands are enabled with optional features.
 
 For the main user guide, see [USER_GUIDE.md](USER_GUIDE.md).
 
@@ -16,6 +16,15 @@ For the main user guide, see [USER_GUIDE.md](USER_GUIDE.md).
 | Flatpak | `flatpak run --command=rustconn-cli io.github.totoshko88.RustConn [command]` |
 
 For Flatpak, create a shell alias to save typing (see [Flatpak Usage](#flatpak-usage) below).
+
+## Build Feature Sets
+
+| Feature set | Includes |
+|-------------|----------|
+| Default / `--no-default-features` | Headless management commands: config, list/show, add/update/delete, import/export, groups, tags, templates, clusters, variables, sync metadata, stats, shell completions |
+| `client-launch` | Optional launch paths such as `connect` and desktop file-manager integration |
+| `secret-management` | Optional `secret` commands and system keyring support |
+| `full` | `client-launch` + `secret-management` |
 
 ---
 
@@ -307,6 +316,9 @@ Zero Trust provider flags:
 | `--custom-command` | `generic` | Command template with `{host}`, `{user}`, `{port}` placeholders |
 
 ### connect — Initiate a connection
+
+Available only when `rustconn-cli` is built with `--features client-launch` or
+`--features full`.
 
 ```bash
 rustconn-cli connect "Server" [--dry-run]
@@ -703,6 +715,9 @@ rustconn-cli var delete "my_var"
 
 ### secret — Manage secret backends
 
+Available only when `rustconn-cli` is built with `--features secret-management`
+or `--features full`.
+
 Manage credentials stored in secret backends (system keyring, KeePass, Bitwarden, 1Password, Passbolt, Pass).
 
 | Subcommand | Description |
@@ -973,7 +988,6 @@ When running RustConn as a Flatpak, the CLI requires the full Flatpak invocation
 ```bash
 flatpak run --command=rustconn-cli io.github.totoshko88.RustConn list
 flatpak run --command=rustconn-cli io.github.totoshko88.RustConn add -n "Server" -H 10.0.0.1
-flatpak run --command=rustconn-cli io.github.totoshko88.RustConn connect "Server"
 ```
 
 Create a shell alias to simplify this:
@@ -988,7 +1002,6 @@ Then use it like the native binary:
 ```bash
 rcli list
 rcli add -n "Server" -H 10.0.0.1
-rcli connect "Server"
 ```
 
 For shell completions in Flatpak:
@@ -1025,7 +1038,7 @@ rustconn-cli list --format csv --protocol ssh | tail -n +2 | while IFS=, read -r
     echo "Checking $name at $host:$port"
 done
 
-# Dry-run a connection to see the command
+# Dry-run a connection to see the command (requires `client-launch` or `full`)
 rustconn-cli connect "Production DB" --dry-run
 
 # Get all connections in a group with their details

--- a/rustconn-cli/Cargo.toml
+++ b/rustconn-cli/Cargo.toml
@@ -12,7 +12,7 @@ name = "rustconn-cli"
 path = "src/main.rs"
 
 [dependencies]
-rustconn-core = { path = "../rustconn-core", version = "0.18.1" }
+rustconn-core = { path = "../rustconn-core", version = "0.18.1", default-features = false }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -27,6 +27,15 @@ secrecy = { workspace = true }
 zeroize = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[features]
+default = []
+# Minimal/default CLI is headless management: config, CRUD, list/show,
+# import/export, tests, groups, tags, templates, sync metadata, stats, etc.
+client-launch = []
+secret-management = ["rustconn-core/system-keyring"]
+desktop-integration = ["client-launch", "secret-management"]
+full = ["desktop-integration"]
 
 [dev-dependencies]
 tempfile = "3.26"

--- a/rustconn-cli/src/cli.rs
+++ b/rustconn-cli/src/cli.rs
@@ -27,7 +27,7 @@ pub struct Cli {
     pub quiet: bool,
 
     /// Disable colored output
-    #[arg(long, global = true, env = "NO_COLOR")]
+    #[arg(long, global = true)]
     pub no_color: bool,
 
     #[command(subcommand)]
@@ -58,6 +58,7 @@ pub enum Commands {
     },
 
     /// Connect to a server by name or ID
+    #[cfg(feature = "client-launch")]
     #[command(about = "Initiate a connection to a remote server")]
     Connect {
         /// Connection name or UUID
@@ -947,6 +948,7 @@ pub enum Commands {
     Var(VariableCommands),
 
     /// Manage secret backends and credentials
+    #[cfg(feature = "secret-management")]
     #[command(subcommand, about = "Manage secret backends and credentials")]
     Secret(SecretCommands),
 
@@ -1608,6 +1610,7 @@ pub enum VariableCommands {
 }
 
 /// Secret backend subcommands
+#[cfg(feature = "secret-management")]
 #[derive(Subcommand)]
 pub enum SecretCommands {
     /// Show available secret backends and their status

--- a/rustconn-cli/src/commands/mod.rs
+++ b/rustconn-cli/src/commands/mod.rs
@@ -4,6 +4,7 @@ mod add;
 mod cloud_sync;
 mod cluster;
 mod completions;
+#[cfg(feature = "client-launch")]
 mod connect;
 mod delete;
 mod duplicate;
@@ -17,6 +18,7 @@ mod monitor;
 mod move_cmd;
 mod pin;
 mod recording;
+#[cfg(feature = "secret-management")]
 mod secret;
 mod sftp;
 mod show;
@@ -56,6 +58,7 @@ pub fn dispatch(config_path: Option<&Path>, command: Commands) -> Result<(), Cli
             group.as_deref(),
             tag.as_deref(),
         ),
+        #[cfg(feature = "client-launch")]
         Commands::Connect { name, dry_run } => connect::cmd_connect(config_path, &name, dry_run),
         Commands::Add {
             name,
@@ -464,6 +467,7 @@ pub fn dispatch(config_path: Option<&Path>, command: Commands) -> Result<(), Cli
         Commands::Template(subcmd) => template::cmd_template(config_path, subcmd),
         Commands::Cluster(subcmd) => cluster::cmd_cluster(config_path, subcmd),
         Commands::Var(subcmd) => variable::cmd_var(config_path, subcmd),
+        #[cfg(feature = "secret-management")]
         Commands::Secret(subcmd) => secret::cmd_secret(config_path, subcmd),
         Commands::SmartFolder(subcmd) => smart_folder::cmd_smart_folder(config_path, subcmd),
         Commands::DynamicFolder(subcmd) => dynamic_folder::cmd_dynamic_folder(config_path, subcmd),

--- a/rustconn-cli/src/commands/sftp.rs
+++ b/rustconn-cli/src/commands/sftp.rs
@@ -93,43 +93,55 @@ pub fn cmd_sftp(
             ));
         }
     } else {
-        // Resolve the login home directory so the file manager opens where the
-        // user has access instead of the server root (issue #212).
-        let uri = rustconn_core::sftp::build_sftp_browser_uri(connection, &groups)
-            .ok_or_else(|| CliError::Protocol("Failed to build SFTP URI".to_string()))?;
+        #[cfg(feature = "client-launch")]
+        {
+            // Resolve the login home directory so the file manager opens where the
+            // user has access instead of the server root (issue #212).
+            let uri = rustconn_core::sftp::build_sftp_browser_uri(connection, &groups)
+                .ok_or_else(|| CliError::Protocol("Failed to build SFTP URI".to_string()))?;
 
-        println!("Opening SFTP file browser for '{}'...", connection.name);
-        println!("URI: {uri}");
+            println!("Opening SFTP file browser for '{}'...", connection.name);
+            println!("URI: {uri}");
 
-        // Launch file manager with agent env injected. On KDE,
-        // xdg-open routes through D-Bus to an already-running
-        // Dolphin that won't have our env.
-        let mut proc = std::process::Command::new("dolphin");
-        proc.args(["--new-window", &uri]);
-        rustconn_core::sftp::apply_agent_env(&mut proc);
-        if proc.spawn().is_ok() {
-            return Ok(());
+            // Launch file manager with agent env injected. On KDE,
+            // xdg-open routes through D-Bus to an already-running
+            // Dolphin that won't have our env.
+            let mut proc = std::process::Command::new("dolphin");
+            proc.args(["--new-window", &uri]);
+            rustconn_core::sftp::apply_agent_env(&mut proc);
+            if proc.spawn().is_ok() {
+                return Ok(());
+            }
+
+            let mut proc = std::process::Command::new("nautilus");
+            proc.args(["--new-window", &uri]);
+            rustconn_core::sftp::apply_agent_env(&mut proc);
+            if proc.spawn().is_ok() {
+                return Ok(());
+            }
+
+            let mut proc = std::process::Command::new(rustconn_core::secret::url_open_command());
+            proc.arg(&uri);
+            rustconn_core::sftp::apply_agent_env(&mut proc);
+            if proc.spawn().is_ok() {
+                return Ok(());
+            }
+
+            return Err(CliError::Connection(
+                "Failed to open file manager. Try --cli to use sftp \
+                 directly"
+                    .to_string(),
+            ));
         }
 
-        let mut proc = std::process::Command::new("nautilus");
-        proc.args(["--new-window", &uri]);
-        rustconn_core::sftp::apply_agent_env(&mut proc);
-        if proc.spawn().is_ok() {
-            return Ok(());
+        #[cfg(not(feature = "client-launch"))]
+        {
+            return Err(CliError::Connection(
+                "SFTP file-browser launch is not compiled in this minimal CLI. \
+                 Use --cli or --mc, or build with the client-launch feature."
+                    .to_string(),
+            ));
         }
-
-        let mut proc = std::process::Command::new(rustconn_core::secret::url_open_command());
-        proc.arg(&uri);
-        rustconn_core::sftp::apply_agent_env(&mut proc);
-        if proc.spawn().is_ok() {
-            return Ok(());
-        }
-
-        return Err(CliError::Connection(
-            "Failed to open file manager. Try --cli to use sftp \
-             directly"
-                .to_string(),
-        ));
     }
 
     Ok(())

--- a/rustconn-cli/src/main.rs
+++ b/rustconn-cli/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
     let cli = Cli::parse();
     let config_path = cli.config.as_deref();
 
-    color::init(cli.no_color);
+    color::init(cli.no_color || std::env::var_os("NO_COLOR").is_some());
     setup_logging(cli.verbose, cli.quiet);
 
     let result = commands::dispatch(config_path, cli.command);

--- a/rustconn-cli/tests/integration_tests.rs
+++ b/rustconn-cli/tests/integration_tests.rs
@@ -48,10 +48,6 @@ fn test_help_command() {
         "Help should mention program name"
     );
     assert!(stdout.contains("list"), "Help should mention list command");
-    assert!(
-        stdout.contains("connect"),
-        "Help should mention connect command"
-    );
     assert!(stdout.contains("add"), "Help should mention add command");
     assert!(
         stdout.contains("export"),
@@ -201,33 +197,6 @@ fn test_list_csv_format() {
 // ============================================================================
 // Error Handling Tests
 // ============================================================================
-
-#[test]
-fn test_connect_nonexistent() {
-    let temp_dir = TempDir::new().expect("Failed to create temp dir");
-
-    let output = run_cli(&["connect", "nonexistent"], Some(temp_dir.path()));
-
-    // Should fail with exit code 2 (connection not found)
-    assert!(
-        !output.status.success(),
-        "Connect to nonexistent should fail"
-    );
-
-    let exit_code = output.status.code().unwrap_or(-1);
-    assert!(
-        exit_code == 1 || exit_code == 2,
-        "Exit code should be 1 or 2 for connection error. Got: {exit_code}"
-    );
-
-    let stderr = stderr_str(&output);
-    assert!(
-        stderr.contains("not found")
-            || stderr.contains("Error")
-            || stderr.contains("No connections"),
-        "Should show error message. Got: {stderr}"
-    );
-}
 
 #[test]
 fn test_import_nonexistent_file() {

--- a/rustconn-core/Cargo.toml
+++ b/rustconn-core/Cargo.toml
@@ -88,23 +88,27 @@ ironrdp-egfx = { version = "0.3", features = ["openh264-libloading"], optional =
 # RD Gateway (MS-TSGU) — HTTPS tunneling for RDP through corporate gateways
 ironrdp-mstsgu = { version = "0.0.1", features = ["native-tls"], optional = true }
 # Pin native-tls to avoid Tlsv13 compile bug in 0.2.17
-native-tls = { workspace = true }
+native-tls = { workspace = true, optional = true }
 nix = { version = "0.31.2", features = ["fs", "signal", "process"] }
 fs2 = "0.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-security-framework = "3.3"
+security-framework = { version = "3.3", optional = true }
 
 # Secret Service (keyring) client. Gated to non-macOS so oo7 NEVER compiles on
 # macOS (which uses security-framework above). Used by the LibSecret/keyring
 # path in Part C.
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-oo7 = { workspace = true }
+oo7 = { workspace = true, optional = true }
 
 # Note: ironrdp-rdpdr-native 0.7 requires ironrdp-rdpdr 0.7.x which matches ironrdp 0.17
 
 [features]
-default = ["vnc-embedded", "rdp-embedded", "gfx-h264", "rd-gateway"]
+default = []
+# Domain-only builds should keep this crate usable without desktop/session
+# integration dependencies. Enable the following features only in crates that
+# embed clients or integrate with the host desktop keyring.
+system-keyring = ["dep:oo7", "dep:security-framework"]
 vnc-embedded = ["dep:vnc-rs", "dep:zune-jpeg"]
 # rdp-embedded feature enables the RdpClient struct with IronRDP
 rdp-embedded = [
@@ -112,6 +116,7 @@ rdp-embedded = [
     "dep:ironrdp-input",
     "dep:ironrdp-tokio",
     "dep:ironrdp-tls",
+    "dep:native-tls",
 ]
 # gfx-h264 enables EGFX pipeline with H.264/AVC decoding (requires rdp-embedded)
 gfx-h264 = ["dep:ironrdp-egfx", "rdp-embedded"]

--- a/rustconn-core/src/lib.rs
+++ b/rustconn-core/src/lib.rs
@@ -10,15 +10,21 @@
 //! - [`connection`] - Connection CRUD operations and managers
 //! - [`protocol`] - Protocol trait and implementations (SSH, RDP, VNC, SPICE, Telnet, Serial, SFTP, Kubernetes)
 //! - [`import`] / [`export`] - Format converters (Remmina, Asbru-CM, SSH config, Ansible, MobaXterm)
-//! - [`secret`] - Credential backends (`KeePassXC`, libsecret)
+//! - [`secret`] - Credential backends and resolvers; host keyring integration is optional
 //! - [`search`] - Fuzzy search with caching and debouncing
 //! - [`automation`] - Expect scripts, key sequences, tasks
 //! - [`performance`] - Connection-string interner (dedup) + search debouncer
 //!
 //! # Feature Flags
 //!
-//! - `vnc-embedded` - Native VNC client via `vnc-rs` (default)
-//! - `rdp-embedded` - Native RDP client via `IronRDP` (default)
+//! The default feature set is intentionally empty so `rustconn-core` can be used
+//! as a headless domain library.
+//!
+//! - `system-keyring` - Host keyring integration (`oo7`/macOS Keychain)
+//! - `vnc-embedded` - Native VNC client via `vnc-rs`
+//! - `rdp-embedded` - Native RDP client via `IronRDP`
+//! - `gfx-h264` - RDP EGFX/H.264 pipeline support
+//! - `rd-gateway` - Native RD Gateway tunneling for embedded RDP
 //!
 //! SPICE sessions use an external viewer (virt-viewer/remote-viewer); the
 //! native embedded SPICE client was removed in 0.18.0.
@@ -26,6 +32,7 @@
 // Enable missing_docs warning for public API documentation
 #![warn(missing_docs)]
 
+// Domain model, persistence, and headless management modules.
 pub mod activity_monitor;
 pub mod automation;
 pub mod busy;
@@ -52,7 +59,6 @@ pub mod password_generator;
 pub mod performance;
 pub mod progress;
 pub mod protocol;
-pub mod rdp_client;
 pub mod search;
 pub mod secret;
 pub mod session;
@@ -61,7 +67,6 @@ pub mod shell_escape;
 pub mod smart_folder;
 pub mod snap;
 pub mod snippet;
-pub mod spice_client;
 pub mod split;
 pub mod ssh_agent;
 pub mod ssh_tunnel;
@@ -73,10 +78,16 @@ pub mod tracing;
 pub mod tunnel_manager;
 pub mod tunnel_preview;
 pub mod variables;
-pub mod vnc_client;
 pub mod wol;
 
 pub mod workspace;
+
+// Optional desktop/client integration modules. These modules expose pure config
+// and availability types without their heavy runtime dependencies unless the
+// corresponding feature is enabled.
+pub mod rdp_client;
+pub mod spice_client;
+pub mod vnc_client;
 
 // =============================================================================
 // Convenience re-exports
@@ -193,12 +204,10 @@ pub use rdp_client::quick_actions::{
     QUICK_ACTIONS, QuickAction, build_enter_sequence, build_hotkey_sequence, build_open_run_dialog,
     run_command_for,
 };
-#[cfg(feature = "rdp-embedded")]
-pub use rdp_client::{AudioFormatInfo, RdpClient, RdpCommandSender, RdpEventReceiver};
 pub use rdp_client::{
-    ClipboardFormatInfo, PixelFormat, RdpClientCommand, RdpClientConfig, RdpClientError,
-    RdpClientEvent, RdpRect, RdpSecurityProtocol, convert_to_bgra, create_frame_update,
-    create_frame_update_with_conversion,
+    AudioFormatInfo, ClipboardFormatInfo, PixelFormat, RdpClientCommand, RdpClientConfig,
+    RdpClientError, RdpClientEvent, RdpRect, RdpSecurityProtocol, convert_to_bgra,
+    create_frame_update, create_frame_update_with_conversion,
     input::{
         CoordinateTransform,
         MAX_RDP_HEIGHT,
@@ -222,6 +231,8 @@ pub use rdp_client::{
     },
     is_embedded_rdp_available, keyval_to_unicode,
 };
+#[cfg(feature = "rdp-embedded")]
+pub use rdp_client::{RdpClient, RdpCommandSender, RdpEventReceiver};
 pub use search::{
     ConnectionSearchResult, DebouncedSearchEngine, MatchHighlight, SearchEngine, SearchError,
     SearchFilter, SearchQuery, SearchResult, benchmark,
@@ -237,10 +248,9 @@ pub use secret::{
     PassBackend, PendingCredentialResolution, SecretBackend, SecretManager, VerifiedCredentials,
     parse_keepassxc_version, resolve_with_callback, spawn_credential_resolution,
 };
-// `LibSecretBackend` is compiled only on non-macOS (macOS uses the Keychain and
-// never builds the oo7-backed libsecret client), so its re-export is split out
-// of the grouped `pub use` above and gated separately.
-#[cfg(not(target_os = "macos"))]
+// Host keyring backends are compiled only when explicitly requested. The
+// headless default keeps DBus/macOS Security.framework out of rustconn-core.
+#[cfg(all(feature = "system-keyring", not(target_os = "macos")))]
 pub use secret::LibSecretBackend;
 pub use session::{
     LogConfig, LogContext, LogError, LogResult, Session, SessionLogger, SessionManager,

--- a/rustconn-core/src/rdp_client/audio.rs
+++ b/rustconn-core/src/rdp_client/audio.rs
@@ -12,78 +12,13 @@
 //! 4. Backend sends data to GUI via event channel
 //! 5. GUI plays audio using platform audio API (cpal/rodio)
 
-use super::RdpClientEvent;
+use super::{AudioFormatInfo, RdpClientEvent};
 use ironrdp::core::impl_as_any;
 use ironrdp::rdpsnd::client::RdpsndClientHandler;
 use ironrdp::rdpsnd::pdu::{AudioFormat, AudioFormatFlags, PitchPdu, VolumePdu, WaveFormat};
 use std::borrow::Cow;
 use std::sync::mpsc::Sender;
 use tracing::{debug, trace};
-
-/// Audio format information for GUI playback
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AudioFormatInfo {
-    /// Format tag (1 = PCM, 6 = A-Law, 7 = μ-Law, etc.)
-    pub format_tag: u16,
-    /// Number of channels (1 = mono, 2 = stereo)
-    pub channels: u16,
-    /// Samples per second (e.g., 44100, 48000)
-    pub samples_per_sec: u32,
-    /// Average bytes per second
-    pub avg_bytes_per_sec: u32,
-    /// Block alignment
-    pub block_align: u16,
-    /// Bits per sample (8, 16, 24, 32)
-    pub bits_per_sample: u16,
-}
-
-impl AudioFormatInfo {
-    /// PCM format tag
-    pub const FORMAT_PCM: u16 = 1;
-    /// A-Law format tag
-    pub const FORMAT_ALAW: u16 = 6;
-    /// μ-Law format tag
-    pub const FORMAT_MULAW: u16 = 7;
-
-    /// Creates a new audio format info
-    #[must_use]
-    pub fn new(format_tag: u16, channels: u16, samples_per_sec: u32, bits_per_sample: u16) -> Self {
-        let block_align = channels * (bits_per_sample / 8);
-        let avg_bytes_per_sec = samples_per_sec * u32::from(block_align);
-        Self {
-            format_tag,
-            channels,
-            samples_per_sec,
-            avg_bytes_per_sec,
-            block_align,
-            bits_per_sample,
-        }
-    }
-
-    /// Creates a standard CD-quality PCM format (44100 Hz, 16-bit, stereo)
-    #[must_use]
-    pub fn cd_quality() -> Self {
-        Self::new(Self::FORMAT_PCM, 2, 44100, 16)
-    }
-
-    /// Creates a DVD-quality PCM format (48000 Hz, 16-bit, stereo)
-    #[must_use]
-    pub fn dvd_quality() -> Self {
-        Self::new(Self::FORMAT_PCM, 2, 48000, 16)
-    }
-
-    /// Returns true if this is a PCM format
-    #[must_use]
-    pub const fn is_pcm(&self) -> bool {
-        self.format_tag == Self::FORMAT_PCM
-    }
-
-    /// Returns the number of bytes per sample (all channels)
-    #[must_use]
-    pub const fn bytes_per_sample(&self) -> u16 {
-        self.block_align
-    }
-}
 
 impl From<&AudioFormat> for AudioFormatInfo {
     fn from(format: &AudioFormat) -> Self {

--- a/rustconn-core/src/rdp_client/event.rs
+++ b/rustconn-core/src/rdp_client/event.rs
@@ -30,6 +30,76 @@ pub struct ClipboardFormatInfo {
     pub name: Option<String>,
 }
 
+/// Audio format information for RDP audio playback.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AudioFormatInfo {
+    /// Format tag (1 = PCM, 6 = A-Law, 7 = μ-Law, etc.)
+    pub format_tag: u16,
+    /// Number of channels (1 = mono, 2 = stereo)
+    pub channels: u16,
+    /// Samples per second (e.g., 44100, 48000)
+    pub samples_per_sec: u32,
+    /// Average bytes per second
+    pub avg_bytes_per_sec: u32,
+    /// Block alignment
+    pub block_align: u16,
+    /// Bits per sample (8, 16, 24, 32)
+    pub bits_per_sample: u16,
+}
+
+impl AudioFormatInfo {
+    /// PCM format tag
+    pub const FORMAT_PCM: u16 = 1;
+    /// A-Law format tag
+    pub const FORMAT_ALAW: u16 = 6;
+    /// μ-Law format tag
+    pub const FORMAT_MULAW: u16 = 7;
+
+    /// Creates a new audio format info
+    #[must_use]
+    pub const fn new(
+        format_tag: u16,
+        channels: u16,
+        samples_per_sec: u32,
+        bits_per_sample: u16,
+    ) -> Self {
+        let block_align = channels * (bits_per_sample / 8);
+        let avg_bytes_per_sec = samples_per_sec * block_align as u32;
+        Self {
+            format_tag,
+            channels,
+            samples_per_sec,
+            avg_bytes_per_sec,
+            block_align,
+            bits_per_sample,
+        }
+    }
+
+    /// Creates a standard CD-quality PCM format (44100 Hz, 16-bit, stereo)
+    #[must_use]
+    pub const fn cd_quality() -> Self {
+        Self::new(Self::FORMAT_PCM, 2, 44100, 16)
+    }
+
+    /// Creates a DVD-quality PCM format (48000 Hz, 16-bit, stereo)
+    #[must_use]
+    pub const fn dvd_quality() -> Self {
+        Self::new(Self::FORMAT_PCM, 2, 48000, 16)
+    }
+
+    /// Returns true if this is a PCM format
+    #[must_use]
+    pub const fn is_pcm(&self) -> bool {
+        self.format_tag == Self::FORMAT_PCM
+    }
+
+    /// Returns the number of bytes per sample (all channels)
+    #[must_use]
+    pub const fn bytes_per_sample(&self) -> u16 {
+        self.block_align
+    }
+}
+
 /// File information for clipboard file transfers (`CF_HDROP`)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClipboardFileInfo {
@@ -500,7 +570,7 @@ pub enum RdpClientEvent {
 
     // ========== Audio Events ==========
     /// Audio format changed (server selected a format)
-    AudioFormatChanged(super::audio::AudioFormatInfo),
+    AudioFormatChanged(AudioFormatInfo),
 
     /// Audio data received from server
     AudioData {

--- a/rustconn-core/src/rdp_client/mod.rs
+++ b/rustconn-core/src/rdp_client/mod.rs
@@ -1,11 +1,14 @@
-//! Pure Rust RDP client for embedded RDP sessions
+//! RDP client boundary for domain types and optional embedded sessions
 //!
-//! This module provides an RDP client implementation using the `ironrdp` crate,
-//! enabling true embedded RDP sessions in GTK4 without external processes.
+//! This module always exposes RDP configuration, events, command types, backend
+//! detection, and argument helpers that are useful to headless callers. The
+//! actual embedded RDP runtime is compiled only with the `rdp-embedded` feature,
+//! so a minimal `rustconn-core` build does not pull IronRDP or client runtime
+//! dependencies.
 //!
 //! # Architecture
 //!
-//! The RDP client runs in a background thread with its own Tokio runtime and
+//! When enabled, the RDP client runs in a background thread with its own Tokio runtime and
 //! communicates with the GUI through channels:
 //! - `RdpClientEvent` channel: framebuffer updates, resolution changes, etc.
 //! - `RdpClientCommand` channel: keyboard/mouse input, disconnect requests
@@ -68,8 +71,6 @@ pub mod reconnect;
 
 pub mod quick_actions;
 
-#[cfg(feature = "rdp-embedded")]
-pub use audio::AudioFormatInfo;
 pub use backend::{BackendDetectionResult, RdpBackend, RdpBackendSelector};
 #[cfg(feature = "rdp-embedded")]
 pub use client::{RdpClient, RdpClientState, RdpCommandSender, RdpEventReceiver};
@@ -78,8 +79,9 @@ pub use config::{
 };
 pub use error::RdpClientError;
 pub use event::{
-    ClipboardFileInfo, ClipboardFormatInfo, PixelFormat, RdpClientCommand, RdpClientEvent, RdpRect,
-    convert_to_bgra, create_frame_update, create_frame_update_with_conversion,
+    AudioFormatInfo, ClipboardFileInfo, ClipboardFormatInfo, PixelFormat, RdpClientCommand,
+    RdpClientEvent, RdpRect, convert_to_bgra, create_frame_update,
+    create_frame_update_with_conversion,
 };
 pub use gateway::{GatewayAuthMethod, GatewayConfig, GatewayError, GatewayState};
 pub use graphics::{

--- a/rustconn-core/src/secret/keyring.rs
+++ b/rustconn-core/src/secret/keyring.rs
@@ -18,16 +18,17 @@
 use crate::error::{SecretError, SecretResult};
 
 // oo7 attribute maps are only built on the in-process (non-macOS) path.
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(feature = "system-keyring", not(target_os = "macos")))]
 use std::collections::HashMap;
 
 // secret-tool subprocess machinery is only used by the retained macOS path.
-#[cfg(target_os = "macos")]
+#[cfg(all(feature = "system-keyring", target_os = "macos"))]
 use std::process::Stdio;
-#[cfg(target_os = "macos")]
+#[cfg(all(feature = "system-keyring", target_os = "macos"))]
 use tokio::process::Command;
 
 /// Application identifier used as the `application` attribute in keyring entries
+#[cfg(feature = "system-keyring")]
 const APP_ID: &str = "rustconn";
 
 /// Builds the two-attribute map used to identify a keyring entry.
@@ -35,7 +36,7 @@ const APP_ID: &str = "rustconn";
 /// The scheme (`application` + `key`) is identical to the one the old
 /// `secret-tool` path wrote, so items round-trip across both mechanisms
 /// (backward compatibility, R11.1).
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(feature = "system-keyring", not(target_os = "macos")))]
 fn build_attributes(key: &str) -> HashMap<String, String> {
     let mut attrs = HashMap::new();
     attrs.insert("application".to_string(), APP_ID.to_string());
@@ -56,7 +57,7 @@ fn build_attributes(key: &str) -> HashMap<String, String> {
 /// Service, not to retry the store/search/delete. `ZBus`/`IO` are raw
 /// wire/socket failures reaching the bus; the two `Service` sub-cases are a
 /// broken transport (`ZBus`) or a vanished session (`NoSession`).
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(feature = "system-keyring", not(target_os = "macos")))]
 fn is_transport_failure(e: &oo7::dbus::Error) -> bool {
     use oo7::dbus::{Error, ServiceError};
     matches!(
@@ -77,7 +78,7 @@ fn is_transport_failure(e: &oo7::dbus::Error) -> bool {
 ///
 /// Messages carry only oo7's `Display` (operation/attribute context) and never
 /// secret material.
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(feature = "system-keyring", not(target_os = "macos")))]
 #[expect(
     clippy::needless_pass_by_value,
     reason = "mirrors the by-value map_err adapter signature; the three wrappers move the error in"
@@ -100,7 +101,7 @@ fn map_oo7_error(
 ///
 /// Establishing the connection is a pure transport/service concern, so any
 /// error here is always [`SecretError::BackendUnavailable`] (R9.3).
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(feature = "system-keyring", not(target_os = "macos")))]
 #[expect(
     clippy::needless_pass_by_value,
     reason = "passed directly to Result::map_err, which hands the error over by value"
@@ -110,19 +111,19 @@ pub(crate) fn map_oo7_service_error(e: oo7::dbus::Error) -> SecretError {
 }
 
 /// Maps a create/update (`Collection::create_item`) failure onto `SecretError`.
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(feature = "system-keyring", not(target_os = "macos")))]
 pub(crate) fn map_oo7_store_error(e: oo7::dbus::Error) -> SecretError {
     map_oo7_error(e, SecretError::StoreFailed, "oo7 store failed")
 }
 
 /// Maps a search/read (`search_items` / `Item::secret`) failure onto `SecretError`.
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(feature = "system-keyring", not(target_os = "macos")))]
 pub(crate) fn map_oo7_retrieve_error(e: oo7::dbus::Error) -> SecretError {
     map_oo7_error(e, SecretError::RetrieveFailed, "oo7 retrieve failed")
 }
 
 /// Maps a delete (`Item::delete`) failure onto `SecretError`.
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(feature = "system-keyring", not(target_os = "macos")))]
 pub(crate) fn map_oo7_delete_error(e: oo7::dbus::Error) -> SecretError {
     map_oo7_error(e, SecretError::DeleteFailed, "oo7 delete failed")
 }
@@ -138,7 +139,7 @@ pub(crate) fn map_oo7_delete_error(e: oo7::dbus::Error) -> SecretError {
 ///
 /// On the oo7 path there is no `secret-tool` binary to probe; this now means
 /// "a Secret Service responded over D-Bus".
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(feature = "system-keyring", not(target_os = "macos")))]
 pub async fn is_secret_tool_available() -> bool {
     oo7::dbus::Service::new().await.is_ok()
 }
@@ -151,7 +152,7 @@ pub async fn is_secret_tool_available() -> bool {
 /// # Errors
 /// Returns `SecretError::BackendUnavailable` if no Secret Service answers.
 /// Returns `SecretError::StoreFailed` if the item cannot be written.
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(feature = "system-keyring", not(target_os = "macos")))]
 pub async fn store(key: &str, value: &str, label: &str) -> SecretResult<()> {
     let attrs = build_attributes(key);
 
@@ -181,7 +182,7 @@ pub async fn store(key: &str, value: &str, label: &str) -> SecretResult<()> {
 /// Returns `SecretError::BackendUnavailable` if no Secret Service answers.
 /// Returns `SecretError::RetrieveFailed` if the search or read fails, or the
 /// stored value is not valid UTF-8.
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(feature = "system-keyring", not(target_os = "macos")))]
 pub async fn lookup(key: &str) -> SecretResult<Option<String>> {
     let attrs = build_attributes(key);
 
@@ -223,7 +224,7 @@ pub async fn lookup(key: &str) -> SecretResult<Option<String>> {
 /// Returns `SecretError::BackendUnavailable` if no Secret Service answers.
 /// Returns `SecretError::RetrieveFailed` if the search fails, or
 /// `SecretError::DeleteFailed` if an item cannot be removed.
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(feature = "system-keyring", not(target_os = "macos")))]
 pub async fn clear(key: &str) -> SecretResult<()> {
     let attrs = build_attributes(key);
 
@@ -257,7 +258,67 @@ pub async fn clear(key: &str) -> SecretResult<()> {
 /// All keyring operations depend on this tool. If it is missing,
 /// callers should fall back to encrypted-settings storage and
 /// inform the user to install `libsecret-tools`.
-#[cfg(target_os = "macos")]
+#[cfg(not(feature = "system-keyring"))]
+#[expect(
+    clippy::unused_async,
+    reason = "keeps the public async API identical to the feature-enabled keyring implementation"
+)]
+pub async fn is_secret_tool_available() -> bool {
+    false
+}
+
+/// Stores a value in the system keyring.
+///
+/// # Errors
+/// Always returns `SecretError::BackendUnavailable` when `system-keyring` is disabled.
+#[cfg(not(feature = "system-keyring"))]
+#[expect(
+    clippy::unused_async,
+    reason = "keeps the public async API identical to the feature-enabled keyring implementation"
+)]
+pub async fn store(_key: &str, _value: &str, _label: &str) -> SecretResult<()> {
+    Err(SecretError::BackendUnavailable(
+        "system keyring support is not compiled in; enable the \
+         rustconn-core/system-keyring feature"
+            .to_string(),
+    ))
+}
+
+/// Retrieves a value from the system keyring.
+///
+/// # Errors
+/// Always returns `SecretError::BackendUnavailable` when `system-keyring` is disabled.
+#[cfg(not(feature = "system-keyring"))]
+#[expect(
+    clippy::unused_async,
+    reason = "keeps the public async API identical to the feature-enabled keyring implementation"
+)]
+pub async fn lookup(_key: &str) -> SecretResult<Option<String>> {
+    Err(SecretError::BackendUnavailable(
+        "system keyring support is not compiled in; enable the \
+         rustconn-core/system-keyring feature"
+            .to_string(),
+    ))
+}
+
+/// Deletes a value from the system keyring.
+///
+/// # Errors
+/// Always returns `SecretError::BackendUnavailable` when `system-keyring` is disabled.
+#[cfg(not(feature = "system-keyring"))]
+#[expect(
+    clippy::unused_async,
+    reason = "keeps the public async API identical to the feature-enabled keyring implementation"
+)]
+pub async fn clear(_key: &str) -> SecretResult<()> {
+    Err(SecretError::BackendUnavailable(
+        "system keyring support is not compiled in; enable the \
+         rustconn-core/system-keyring feature"
+            .to_string(),
+    ))
+}
+
+#[cfg(all(feature = "system-keyring", target_os = "macos"))]
 pub async fn is_secret_tool_available() -> bool {
     // secret-tool does not support --version; running it without valid
     // arguments prints usage to stderr and exits with code 1.
@@ -279,7 +340,7 @@ pub async fn is_secret_tool_available() -> bool {
 /// Returns `SecretError::BackendUnavailable` if `secret-tool` is not installed.
 /// Returns `SecretError::LibSecret` if `secret-tool` cannot be spawned
 /// or the store command fails.
-#[cfg(target_os = "macos")]
+#[cfg(all(feature = "system-keyring", target_os = "macos"))]
 pub async fn store(key: &str, value: &str, label: &str) -> SecretResult<()> {
     use tokio::io::AsyncWriteExt;
 
@@ -328,7 +389,7 @@ pub async fn store(key: &str, value: &str, label: &str) -> SecretResult<()> {
 ///
 /// # Errors
 /// Returns `SecretError::LibSecret` if `secret-tool` cannot be spawned.
-#[cfg(target_os = "macos")]
+#[cfg(all(feature = "system-keyring", target_os = "macos"))]
 pub async fn lookup(key: &str) -> SecretResult<Option<String>> {
     let output = Command::new("secret-tool")
         .env("PATH", crate::cli_download::get_extended_path())
@@ -353,7 +414,7 @@ pub async fn lookup(key: &str) -> SecretResult<Option<String>> {
 ///
 /// # Errors
 /// Returns `SecretError::DeleteFailed` if the clear command fails.
-#[cfg(target_os = "macos")]
+#[cfg(all(feature = "system-keyring", target_os = "macos"))]
 pub async fn clear(key: &str) -> SecretResult<()> {
     let output = Command::new("secret-tool")
         .env("PATH", crate::cli_download::get_extended_path())

--- a/rustconn-core/src/secret/manager.rs
+++ b/rustconn-core/src/secret/manager.rs
@@ -250,10 +250,14 @@ impl SecretManager {
                 // macOS never constructs LibSecretBackend (oo7 is not compiled
                 // there) — it routes to the system Keychain instead (R10.1,
                 // R10.2). Non-macOS keeps the oo7-backed libsecret client.
-                #[cfg(target_os = "macos")]
+                #[cfg(all(feature = "system-keyring", target_os = "macos"))]
                 backends.push(Arc::new(super::MacOsKeychainBackend::new()));
-                #[cfg(not(target_os = "macos"))]
+                #[cfg(all(feature = "system-keyring", not(target_os = "macos")))]
                 backends.push(Arc::new(super::LibSecretBackend::default_app()));
+                #[cfg(not(feature = "system-keyring"))]
+                tracing::debug!(
+                    "System keyring backend selected but rustconn-core/system-keyring is disabled"
+                );
             }
             SecretBackendType::Pass => {
                 backends.push(Arc::new(super::PassBackend::from_secret_settings(settings)));
@@ -264,19 +268,30 @@ impl SecretManager {
                 // Add the system keyring as the operational backend for
                 // non-KeePass lookups (e.g. variable resolution). macOS uses
                 // the Keychain (LibSecretBackend is not compiled there).
-                #[cfg(target_os = "macos")]
+                #[cfg(all(feature = "system-keyring", target_os = "macos"))]
                 backends.push(Arc::new(super::MacOsKeychainBackend::new()));
-                #[cfg(not(target_os = "macos"))]
+                #[cfg(all(feature = "system-keyring", not(target_os = "macos")))]
                 backends.push(Arc::new(super::LibSecretBackend::default_app()));
+                #[cfg(not(feature = "system-keyring"))]
+                tracing::debug!(
+                    "KDBX backend selected without system-keyring; only direct KDBX \
+                     and app-managed fallback backends are available"
+                );
             }
-            #[cfg(target_os = "macos")]
+            #[cfg(all(feature = "system-keyring", target_os = "macos"))]
             SecretBackendType::MacOsKeychain => {
                 backends.push(Arc::new(super::MacOsKeychainBackend::new()));
             }
-            #[cfg(not(target_os = "macos"))]
+            #[cfg(all(feature = "system-keyring", not(target_os = "macos")))]
             SecretBackendType::MacOsKeychain => {
                 // Fallback to libsecret on non-macOS platforms
                 backends.push(Arc::new(super::LibSecretBackend::default_app()));
+            }
+            #[cfg(not(feature = "system-keyring"))]
+            SecretBackendType::MacOsKeychain => {
+                tracing::debug!(
+                    "macOS Keychain backend selected but rustconn-core/system-keyring is disabled"
+                );
             }
             SecretBackendType::EncryptedFile => {
                 // Application-managed encrypted file: addressed by the flat

--- a/rustconn-core/src/secret/mod.rs
+++ b/rustconn-core/src/secret/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides secure credential storage through multiple backends:
 //! - Direct KDBX file access (compatible with `KeePassXC`, GNOME Secrets, `OneKeePass`)
-//! - libsecret for GNOME Keyring/KDE Wallet integration (fallback)
+//! - libsecret / macOS Keychain integration when the `system-keyring` feature is enabled
 //! - Bitwarden CLI integration
 //! - 1Password CLI integration
 //!
@@ -18,10 +18,10 @@ pub mod hierarchy;
 mod kdbx;
 mod kdbx_keyring;
 pub mod keyring;
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(feature = "system-keyring", not(target_os = "macos")))]
 mod libsecret;
 pub(crate) mod local_crypto;
-#[cfg(target_os = "macos")]
+#[cfg(all(feature = "system-keyring", target_os = "macos"))]
 pub mod macos_keychain;
 mod manager;
 mod onepassword;
@@ -61,9 +61,9 @@ pub use kdbx_keyring::{
     delete_kdbx_password_from_keyring, get_kdbx_password_from_keyring,
     store_kdbx_password_in_keyring,
 };
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(feature = "system-keyring", not(target_os = "macos")))]
 pub use libsecret::LibSecretBackend;
-#[cfg(target_os = "macos")]
+#[cfg(all(feature = "system-keyring", target_os = "macos"))]
 pub use macos_keychain::MacOsKeychainBackend;
 pub use manager::{
     BulkOperationResult, CACHE_TTL_SECONDS, CredentialUpdate, SecretManager, StoreOutcome,

--- a/rustconn-core/src/spice_client/mod.rs
+++ b/rustconn-core/src/spice_client/mod.rs
@@ -1,12 +1,12 @@
-//! SPICE session support via an external viewer.
+//! SPICE external-viewer integration boundary.
 //!
 //! SPICE sessions are handled by launching an external viewer
 //! (`remote-viewer`, `virt-viewer`, or `spicy`). This module provides the
 //! connection configuration ([`SpiceClientConfig`]), error type
 //! ([`SpiceClientError`]), and the helpers that detect a viewer and build its
-//! command line ([`detect_spice_viewer`], [`build_spice_viewer_args`]). The
-//! `rustconn` crate spawns the viewer process and tracks it in its external
-//! session registry.
+//! command line ([`detect_spice_viewer`], [`build_spice_viewer_args`]).
+//! Callers that need a strict domain-only build should avoid invoking the
+//! detection/launch helpers and treat [`SpiceClientConfig`] as data.
 //!
 //! # History
 //!

--- a/rustconn-core/src/vnc_client/mod.rs
+++ b/rustconn-core/src/vnc_client/mod.rs
@@ -1,7 +1,8 @@
-//! Pure Rust VNC client for embedded VNC sessions
+//! Optional embedded VNC client integration boundary
 //!
-//! This module provides a VNC client implementation using the `vnc-rs` crate,
-//! enabling true embedded VNC sessions in GTK4 without external processes.
+//! A headless build keeps this module as an availability boundary only. The
+//! `vnc-rs` runtime, VNC config, events, and client types are compiled only with
+//! the `vnc-embedded` feature.
 //!
 //! # Architecture
 //!

--- a/rustconn-core/tests/properties/vnc_client_tests.rs
+++ b/rustconn-core/tests/properties/vnc_client_tests.rs
@@ -1,6 +1,5 @@
 //! Property tests for VNC client module
 
-use proptest::prelude::*;
 use rustconn_core::vnc_client::is_embedded_vnc_available;
 
 // Note: VncClientConfig, VncRect, etc. are only available with vnc-embedded feature
@@ -30,6 +29,7 @@ fn is_embedded_vnc_available_is_const() {
 #[cfg(feature = "vnc-embedded")]
 mod vnc_config_tests {
     use super::*;
+    use proptest::prelude::*;
     use rustconn_core::vnc_client::{VncClientConfig, VncClientEvent, VncRect};
 
     fn arb_host() -> impl Strategy<Value = String> {

--- a/rustconn/Cargo.toml
+++ b/rustconn/Cargo.toml
@@ -12,7 +12,7 @@ name = "rustconn"
 path = "src/main.rs"
 
 [dependencies]
-rustconn-core = { path = "../rustconn-core", version = "0.18.1" }
+rustconn-core = { path = "../rustconn-core", version = "0.18.1", default-features = false }
 tokio = { workspace = true }
 # Event-driven tray message delivery to the GTK main loop (no polling)
 async-channel = { workspace = true }
@@ -54,9 +54,18 @@ nix = { version = "0.31", features = ["signal", "process"] }
 # The native embedded SPICE path was removed in 0.18.0: spice-client 0.2 exposes
 # neither an inputs channel nor raw display frames, so embedding was impossible
 # without forking the crate.
-default = ["tray", "vnc-embedded", "rdp-embedded", "rdp-audio", "rd-gateway", "wayland-native"]
+default = [
+    "tray",
+    "system-keyring",
+    "vnc-embedded",
+    "rdp-embedded",
+    "rdp-audio",
+    "rd-gateway",
+    "wayland-native",
+]
 tray = ["dep:ksni", "dep:resvg"]
 tray-macos = ["dep:tray-icon", "dep:muda", "dep:resvg"]
+system-keyring = ["rustconn-core/system-keyring"]
 vnc-embedded = ["rustconn-core/vnc-embedded"]
 rdp-embedded = ["rustconn-core/rdp-embedded"]
 rd-gateway = ["rustconn-core/rd-gateway"]


### PR DESCRIPTION
Summary:
- split rustconn-core defaults into a headless domain kernel with optional system-keyring, embedded-client, GFX, and RD Gateway features
- keep rustconn-cli default features minimal and gate client-launch/secret-management paths
- remove the obsolete CLI connect integration test expectation and align README/Build Guide/Architecture/CLI Reference with the feature split

Verification:
- cargo check -p rustconn-core --no-default-features
- cargo check -p rustconn-cli --no-default-features
- cargo check -p rustconn-cli --features full
- cargo test -p rustconn-cli --test integration_tests
- cargo clippy -p rustconn-core --no-default-features --all-targets -- -D warnings
- cargo clippy -p rustconn-cli --no-default-features --all-targets -- -D warnings

Notes:
- full GUI cargo check is blocked in this Termux environment by missing Cairo/xproto pkg-config dependencies
- local untracked cargo_ausgabe.txt is intentionally not included