### PR TITLE
fix(window): copy the vault credential when duplicating a connection

### DIFF
--- a/rustconn/src/window/operations.rs
+++ b/rustconn/src/window/operations.rs
@@ -197,17 +197,28 @@ pub fn duplicate_selected_connection(
         return;
     };
 
-    let (conn, new_name) = if let Ok(state_ref) = state.try_borrow() {
+    let (conn, new_name, settings, groups) = if let Ok(state_ref) = state.try_borrow() {
         let Some(conn) = state_ref.get_connection(id).cloned() else {
             return;
         };
         // Generate unique name for duplicate
         let new_name = state_ref
             .generate_unique_connection_name(&format!("{} (copy)", conn.name), conn.protocol);
-        (conn, new_name)
+        // Needed to copy the vault credential once the duplicate exists; read
+        // here so the borrow is released before `create_connection_from`.
+        (
+            conn,
+            new_name,
+            state_ref.settings().clone(),
+            state_ref.list_groups_owned(),
+        )
     } else {
         return;
     };
+
+    // The source connection, kept whole: the vault entry is keyed by name and
+    // UUID, so copying the credential needs both sides of the pair.
+    let original = conn.clone();
 
     // Create duplicate with new ID and name
     let mut duplicate = conn;
@@ -215,6 +226,8 @@ pub fn duplicate_selected_connection(
     duplicate.name = new_name;
     duplicate.created_at = chrono::Utc::now();
     duplicate.updated_at = chrono::Utc::now();
+
+    let duplicate_for_vault = duplicate.clone();
 
     if let Ok(mut state_mut) = state.try_borrow_mut() {
         match state_mut
@@ -235,6 +248,35 @@ pub fn duplicate_selected_connection(
                         crate::toast::ToastType::Success,
                     );
                 });
+
+                // Carry the secret over. A duplicate that keeps
+                // `password_source = Vault` without an entry of its own looks
+                // configured but has none: connecting prompts for a password or
+                // fails outright. Paste, rename and move-to-group all migrate
+                // the credential — duplicate was the only name-changing path
+                // that did not.
+                if duplicate_for_vault.password_source
+                    == rustconn_core::models::PasswordSource::Vault
+                {
+                    crate::utils::spawn_blocking_with_callback(
+                        move || {
+                            crate::vault_ops::copy_vault_credential(
+                                &settings,
+                                &groups,
+                                &original,
+                                &duplicate_for_vault,
+                            )
+                        },
+                        |result| {
+                            if let Err(e) = result {
+                                tracing::warn!(
+                                    error = %e,
+                                    "Failed to copy vault credential on duplicate"
+                                );
+                            }
+                        },
+                    );
+                }
             }
             Err(e) => {
                 tracing::error!("Failed to duplicate connection: {e}");


### PR DESCRIPTION
`duplicate_selected_connection` copied every field of the source
connection, including `password_source = Vault`, but never copied the
vault entry itself. The duplicate therefore looks fully configured while
having no stored secret: connecting to it prompts for a password or
fails to authenticate, and the failure looks like a bug in the vault.

Every other name-changing path already migrates the credential — paste
(`vault_ops.rs`), rename (`vault_ops.rs`) and move-to-group
(`state/connections.rs`). Duplicate was the only one that did not.

Mirror what `AppState::paste_connection` does: snapshot the settings and
the group list before the mutable borrow, then hand the pair to
`copy_vault_credential` on a worker thread once the duplicate exists.
Both key derivations need it — the entry is keyed by name and, as a
fallback, by UUID, and the duplicate gets a fresh `Uuid::new_v4()`.


---

Verified on the Flatpak build (GNOME 50 runtime, `packaging/flatpak/…local.yml`): `cargo fmt --check`, `cargo clippy --workspace --bins --tests` (pedantic + nursery, no warnings) and the test suites pass. This branch also compiles standalone on top of `main`, independently of the other branches I am opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
