### PR TITLE
fix(session): run the post-disconnect task off the GTK main thread

### DIFF
--- a/rustconn/src/window/session_lifecycle.rs
+++ b/rustconn/src/window/session_lifecycle.rs
@@ -567,44 +567,61 @@ impl MainWindow {
                 let executor =
                     TaskExecutor::with_tracker(Arc::new(var_manager), Arc::clone(&post_disconnect_folder_tracker));
 
-                let result = crate::async_utils::with_runtime(|rt| {
-                    rt.block_on(async {
-                        // ponytail: 60s ceiling protects the GTK main thread;
-                        // the task's own timeout (if configured) fires first.
-                        let ceiling = std::time::Duration::from_mins(1);
-                        tokio::time::timeout(ceiling, executor.execute_post_disconnect(
-                            task,
-                            VariableScope::Connection(connection_id),
-                            post_disconnect_folder_id,
-                        ))
-                        .await
-                        .unwrap_or(Err(rustconn_core::automation::TaskError::Timeout(60_000)))
-                    })
-                });
-
-                match result {
-                    Ok(Ok(_)) => {
-                        tracing::info!(
-                            %connection_id,
-                            "Post-disconnect task completed successfully"
-                        );
-                    }
-                    Ok(Err(e)) => {
-                        tracing::warn!(
-                            %connection_id,
-                            command = %task.command,
-                            error = %e,
-                            "Post-disconnect task failed"
-                        );
-                    }
-                    Err(runtime_err) => {
-                        tracing::warn!(
-                            %connection_id,
-                            error = %runtime_err,
-                            "Failed to create async runtime for post-disconnect task"
-                        );
-                    }
-                }
+                // Run it off the main thread. A post-disconnect task is an
+                // arbitrary user command — a script, an ssh, a curl against a
+                // host that may itself be unreachable — and blocking here
+                // freezes the entire application, every other terminal, RDP and
+                // VNC tab included, for as long as it takes: up to the ceiling
+                // below. Nothing further down depends on the outcome; the arms
+                // only log. Same shape the wake-on-LAN host check already uses.
+                let task_for_run = task.clone();
+                let command_for_log = task.command.clone();
+                crate::utils::spawn_blocking_with_callback(
+                    move || {
+                        crate::async_utils::with_runtime(|rt| {
+                            rt.block_on(async {
+                                // ponytail: 60s ceiling bounds the worker thread;
+                                // the task's own timeout (if configured) fires first.
+                                let ceiling = std::time::Duration::from_mins(1);
+                                tokio::time::timeout(
+                                    ceiling,
+                                    executor.execute_post_disconnect(
+                                        &task_for_run,
+                                        VariableScope::Connection(connection_id),
+                                        post_disconnect_folder_id,
+                                    ),
+                                )
+                                .await
+                                .unwrap_or(Err(
+                                    rustconn_core::automation::TaskError::Timeout(60_000),
+                                ))
+                            })
+                        })
+                    },
+                    move |result| match result {
+                        Ok(Ok(_)) => {
+                            tracing::info!(
+                                %connection_id,
+                                "Post-disconnect task completed successfully"
+                            );
+                        }
+                        Ok(Err(e)) => {
+                            tracing::warn!(
+                                %connection_id,
+                                command = %command_for_log,
+                                error = %e,
+                                "Post-disconnect task failed"
+                            );
+                        }
+                        Err(runtime_err) => {
+                            tracing::warn!(
+                                %connection_id,
+                                error = %runtime_err,
+                                "Failed to create async runtime for post-disconnect task"
+                            );
+                        }
+                    },
+                );
             }
 
             // Get history entry ID before session info is removed


### PR DESCRIPTION
The post-disconnect automation task ran inside `with_runtime(|rt|
rt.block_on(...))` directly in the `child-exited` handler, i.e. on the
GTK main thread. A post-disconnect task is an arbitrary user command — a
script, an ssh, a curl against a host that may itself be unreachable —
so closing a tab froze the entire application, every other terminal, RDP
and VNC tab included, until the child exited or the 60 s ceiling fired.
Long enough for the compositor to grey the window and offer Force Quit.

Nothing below the call consumed the result; the match arms only log. Move
the blocking work to `spawn_blocking_with_callback` and keep the arms in
the callback, the same shape the wake-on-LAN host check already uses.


---

Verified on the Flatpak build (GNOME 50 runtime, `packaging/flatpak/…local.yml`): `cargo fmt --check`, `cargo clippy --workspace --bins --tests` (pedantic + nursery, no warnings) and the test suites pass. This branch also compiles standalone on top of `main`, independently of the other branches I am opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
