### PR TITLE
fix(terminal): replace the child-exited handler instead of stacking a new one

### DIFF
--- a/rustconn/src/terminal/mod.rs
+++ b/rustconn/src/terminal/mod.rs
@@ -355,6 +355,18 @@ pub struct TerminalNotebook {
     /// Some terminal clients (e.g. telnet) do not exit on PTY close (SIGHUP),
     /// so an explicit kill is needed (#172).
     vte_child_pids: Rc<RefCell<HashMap<Uuid, i32>>>,
+    /// The live `child-exited` handler of each session, with the terminal it is
+    /// attached to.
+    ///
+    /// An in-place reconnect calls `connect_child_exited` again on the *same*
+    /// VTE widget, so without this the previous handler stays attached and the
+    /// entire disconnect path runs once per handler: one post-disconnect task,
+    /// one host-probe poll and one sidebar decrement for every reconnect the
+    /// session has ever had. The terminal is kept beside the id because a
+    /// handler id is only meaningful to the widget it came from — disconnecting
+    /// a stale one from a fresh widget is a GLib error, hence the weak ref.
+    child_exited_handlers:
+        Rc<RefCell<HashMap<Uuid, (glib::WeakRef<Terminal>, glib::SignalHandlerId)>>>,
     /// Whether to show the Welcome tab when no sessions are open (issue #232).
     /// Shared with signal handlers via `Rc<Cell<bool>>`.
     show_welcome: Rc<std::cell::Cell<bool>>,
@@ -467,6 +479,7 @@ impl TerminalNotebook {
             monitoring: Rc::new(RefCell::new(None)),
             snippet_menu_section: Rc::new(gio::Menu::new()),
             vte_child_pids: Rc::new(RefCell::new(HashMap::new())),
+            child_exited_handlers: Rc::new(RefCell::new(HashMap::new())),
             show_welcome: Rc::new(std::cell::Cell::new(show_welcome)),
         };
 
@@ -498,6 +511,7 @@ impl TerminalNotebook {
         let detached_close = Rc::clone(&self.detached);
         let on_session_ended = Rc::clone(&self.on_session_ended);
         let vte_child_pids = self.vte_child_pids.clone();
+        let child_exited_on_close = Rc::clone(&self.child_exited_handlers);
         let show_welcome_on_close = self.show_welcome.clone();
         let disconnected_on_close = Rc::clone(&self.disconnected_sessions);
         let cursor_row_base_on_close = Rc::clone(&self.cursor_row_base);
@@ -638,6 +652,9 @@ impl TerminalNotebook {
                 drop(pty_relays_on_close.borrow_mut().remove(&session_id));
                 output_observers_on_close.borrow_mut().remove(&session_id);
                 commit_forwarded_on_close.borrow_mut().remove(&session_id);
+                // The widget goes with the tab, so the handler dies with it —
+                // this only keeps the map from growing for the app's lifetime.
+                child_exited_on_close.borrow_mut().remove(&session_id);
 
                 // Kill VTE child process group explicitly (#172).
                 // Some CLI clients (notably telnet) do not exit on SIGHUP
@@ -2053,12 +2070,30 @@ impl TerminalNotebook {
         F: Fn(i32) + 'static,
     {
         if let Some(terminal) = self.get_terminal(session_id) {
+            // Drop whatever a previous connection left on this widget. An
+            // in-place reconnect lands here again on the same terminal, and a
+            // second handler would mean the whole disconnect path runs twice:
+            // two post-disconnect tasks, two host-probe polls, and the
+            // sidebar's active-session count decremented twice for one exit —
+            // which drops a connection to "no active sessions" while another
+            // of its tabs is still live.
+            if let Some((previous_terminal, handler)) =
+                self.child_exited_handlers.borrow_mut().remove(&session_id)
+                && let Some(previous_terminal) = previous_terminal.upgrade()
+            {
+                previous_terminal.disconnect(handler);
+            }
+
             let pids = self.vte_child_pids.clone();
-            terminal.connect_child_exited(move |_terminal, status| {
+            let handler = terminal.connect_child_exited(move |_terminal, status| {
                 // Remove PID — process already exited, no need to kill on tab close
                 pids.borrow_mut().remove(&session_id);
                 callback(status);
             });
+
+            self.child_exited_handlers
+                .borrow_mut()
+                .insert(session_id, (terminal.downgrade(), handler));
         }
     }
 


### PR DESCRIPTION
`connect_child_exited` connected a fresh handler every time it was
called, with no bookkeeping. An in-place reconnect (Reconnect button,
auto-reconnect poll, network-change sweep) calls it again on the *same*
VTE widget, so after N reconnects the terminal carries N+1 handlers and
the next disconnect runs the entire disconnect path N+1 times: N+1
post-disconnect tasks, N+1 host-probe polls and N+1 100 ms UI timers for
one session.

The most visible symptom is the sidebar: `decrement_session_count` runs
once per handler, so a connection with two live tabs drops to "no active
sessions" when one of them disconnects.

Keep the handler id per session and disconnect the previous one before
connecting the new. The terminal is stored beside the id via a weak ref
because a handler id is only meaningful to the widget it came from —
disconnecting a stale id on a fresh widget is a GLib error. The map is
cleared on tab close alongside the other per-session cleanups.


---

Verified on the Flatpak build (GNOME 50 runtime, `packaging/flatpak/…local.yml`): `cargo fmt --check`, `cargo clippy --workspace --bins --tests` (pedantic + nursery, no warnings) and the test suites pass. This branch also compiles standalone on top of `main`, independently of the other branches I am opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
