### PR TITLE
fix(network-monitor): honour the disconnect path's refusal to reconnect

### DIFF
--- a/rustconn/src/terminal/mod.rs
+++ b/rustconn/src/terminal/mod.rs
@@ -313,6 +313,15 @@ pub struct TerminalNotebook {
     /// Cancel tokens for background polling tasks (host check, auto-reconnect, WoL)
     /// Keyed by session_id or connection_id depending on context
     poll_cancel_tokens: Rc<RefCell<HashMap<Uuid, std::sync::Arc<std::sync::atomic::AtomicBool>>>>,
+    /// Sessions an *unattended* sweep is allowed to bring back.
+    ///
+    /// A visible reconnect banner is not consent: the disconnect path shows one
+    /// for a shell the user closed with `exit`, for a failed authentication and
+    /// for a process that crashed on startup — precisely the cases where it
+    /// deliberately refuses to reconnect. Membership here records that decision
+    /// so a network change or a resume from sleep honours it instead of
+    /// re-running the login by itself.
+    auto_reconnect_eligible: Rc<RefCell<std::collections::HashSet<Uuid>>>,
     /// SSH tunnels for jump-host connections (RDP, VNC, SPICE, Telnet).
     /// Killed automatically when the tab is closed.
     ssh_tunnels: Rc<RefCell<HashMap<Uuid, rustconn_core::ssh_tunnel::SshTunnel>>>,
@@ -456,6 +465,7 @@ impl TerminalNotebook {
             active_recordings: Rc::new(RefCell::new(HashSet::new())),
             remote_recordings: RefCell::new(HashMap::new()),
             poll_cancel_tokens: Rc::new(RefCell::new(HashMap::new())),
+            auto_reconnect_eligible: Rc::new(RefCell::new(std::collections::HashSet::new())),
             ssh_tunnels: Rc::new(RefCell::new(HashMap::new())),
             activity_coordinator: Rc::new(RefCell::new(None)),
             tab_containers: Rc::new(RefCell::new(HashMap::new())),
@@ -498,6 +508,7 @@ impl TerminalNotebook {
         let detached_close = Rc::clone(&self.detached);
         let on_session_ended = Rc::clone(&self.on_session_ended);
         let vte_child_pids = self.vte_child_pids.clone();
+        let auto_reconnect_on_close = Rc::clone(&self.auto_reconnect_eligible);
         let show_welcome_on_close = self.show_welcome.clone();
         let disconnected_on_close = Rc::clone(&self.disconnected_sessions);
         let cursor_row_base_on_close = Rc::clone(&self.cursor_row_base);
@@ -638,6 +649,7 @@ impl TerminalNotebook {
                 drop(pty_relays_on_close.borrow_mut().remove(&session_id));
                 output_observers_on_close.borrow_mut().remove(&session_id);
                 commit_forwarded_on_close.borrow_mut().remove(&session_id);
+                auto_reconnect_on_close.borrow_mut().remove(&session_id);
 
                 // Kill VTE child process group explicitly (#172).
                 // Some CLI clients (notably telnet) do not exit on SIGHUP

--- a/rustconn/src/terminal/session_lifecycle.rs
+++ b/rustconn/src/terminal/session_lifecycle.rs
@@ -149,6 +149,30 @@ impl TerminalNotebook {
         self.poll_cancel_tokens.borrow_mut().insert(key, cancel);
     }
 
+    /// Records whether an unattended sweep may reconnect this session.
+    ///
+    /// Called by the disconnect path with the same verdict it reached for its
+    /// own auto-reconnect poll, so the two cannot disagree. Always call it —
+    /// passing `false` clears an earlier `true`, which matters for a session
+    /// that dropped once from a real failure and later exited cleanly.
+    pub fn set_auto_reconnect_eligible(&self, session_id: Uuid, eligible: bool) {
+        let mut set = self.auto_reconnect_eligible.borrow_mut();
+        if eligible {
+            set.insert(session_id);
+        } else {
+            set.remove(&session_id);
+        }
+    }
+
+    /// Whether an unattended sweep may reconnect this session.
+    ///
+    /// Defaults to `false`: a session whose disconnect never reached the
+    /// decision point is left alone rather than logged back in on a guess.
+    #[must_use]
+    pub fn is_auto_reconnect_eligible(&self, session_id: Uuid) -> bool {
+        self.auto_reconnect_eligible.borrow().contains(&session_id)
+    }
+
     /// Cancels and removes a background polling task by key
     pub fn cancel_poll(&self, key: Uuid) {
         if let Some(cancel) = self.poll_cancel_tokens.borrow_mut().remove(&key) {

--- a/rustconn/src/window/network_monitor.rs
+++ b/rustconn/src/window/network_monitor.rs
@@ -261,8 +261,14 @@ fn trigger_reconnect_for_disconnected_sessions(state: &SharedAppState, notebook:
         .get_all_sessions()
         .into_iter()
         .filter(|info| {
-            // Check if the reconnect overlay is visible for this session
+            // The reconnect overlay is visible for this session…
             notebook.is_reconnect_shown(info.id)
+                // …and its disconnect was one this sweep is allowed to undo.
+                // A visible banner is not consent: the disconnect path shows one
+                // for a shell the user closed with `exit` too, and re-entering
+                // that host on the next Wi-Fi roam is not recovery, it is the
+                // app logging in on its own.
+                && notebook.is_auto_reconnect_eligible(info.id)
         })
         .map(|info| (info.id, info.connection_id))
         .collect();

--- a/rustconn/src/window/session_lifecycle.rs
+++ b/rustconn/src/window/session_lifecycle.rs
@@ -755,6 +755,24 @@ impl MainWindow {
                 );
             }
 
+            // Record the verdict for the unattended sweeps (network change,
+            // resume from sleep) before acting on it. They can only see that a
+            // reconnect banner is up, and a banner is also shown for a shell the
+            // user closed with `exit` and for a process that died seconds after
+            // starting — where reconnecting is exactly what must not happen.
+            // Without this, `exit` re-enters the host by itself on the next
+            // Wi-Fi roam.
+            //
+            // The `is_ssh_auth_failure` term deliberately does *not* apply here.
+            // OpenSSH exits 255 for a connection it lost just as it does for a
+            // password it was refused, so carrying that term over would make the
+            // sweep skip precisely the sessions it exists to recover (#217). The
+            // poll below can afford the heuristic because it retries every few
+            // seconds and would spin forever on bad credentials; a sweep fires
+            // once, on a discrete external event, and one re-prompt is a far
+            // smaller price than never recovering a dropped SSH session.
+            notebook_clone.set_auto_reconnect_eligible(session_id, is_failure && !is_rapid_crash);
+
             if is_failure
                 && !is_ssh_auth_failure
                 && !is_rapid_crash


### PR DESCRIPTION
The reconnect sweep that follows a network change or a resume from sleep
picked its victims by asking `is_reconnect_shown` — i.e. "is the
reconnect banner up?". A banner is not consent: the disconnect path
raises one for a shell the user closed with `exit` (the default
`close_on_clean_exit = false` keeps the transcript tab open), for a login
that failed, and for a process that crashed seconds after starting —
exactly the cases where it deliberately refuses to auto-reconnect.

So a tab the user closed by typing `exit` silently logged back into the
host on the next Wi-Fi roam, VPN cycle or wake-up.

Record the verdict where it is made, in the `child-exited` handler, and
require it in the sweep alongside the visible banner. Defaults to not
eligible: a session whose disconnect never reached the decision point is
left alone rather than reconnected on a guess. The manual Reconnect
button is unaffected — only the unattended sweeps consult this.

Note that `is_ssh_auth_failure` is deliberately *not* part of the
eligibility test even though the poll below uses it. OpenSSH exits 255
for a connection it lost just as it does for a password it refused, so
carrying that term over would make the sweep skip the very sessions it
exists to recover (#217). The poll can afford the heuristic because it
retries every few seconds and would spin forever on bad credentials; a
sweep fires once, on a discrete external event.


---

Verified on the Flatpak build (GNOME 50 runtime, `packaging/flatpak/…local.yml`): `cargo fmt --check`, `cargo clippy --workspace --bins --tests` (pedantic + nursery, no warnings) and the test suites pass. This branch also compiles standalone on top of `main`, independently of the other branches I am opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
