### PR TITLE
feat(settings): let the session toolbar require a click instead of hover

### DIFF
--- a/rustconn-core/src/config/settings.rs
+++ b/rustconn-core/src/config/settings.rs
@@ -676,6 +676,17 @@ pub struct UiSettings {
     /// (issue #232).
     #[serde(default = "default_true")]
     pub show_welcome_on_startup: bool,
+    /// Reveal the floating session toolbar when the pointer touches its handle
+    ///
+    /// Default `true`, the long-standing behaviour. The handle sits at the top
+    /// centre of an embedded RDP/VNC view, so moving the pointer towards the
+    /// top of the remote screen — reaching for the remote window's own title
+    /// bar, its close button, or a maximised app's menu — opens the toolbar
+    /// over exactly the area being aimed at. Set to `false` to require a click
+    /// on the handle instead: the handle and every action stay where they are,
+    /// only the accidental trigger goes away.
+    #[serde(default = "default_true")]
+    pub reveal_session_toolbar_on_hover: bool,
     /// Color tab indicators by protocol type
     #[serde(default)]
     pub color_tabs_by_protocol: bool,
@@ -810,6 +821,7 @@ impl Default for UiSettings {
             search_history: Vec::new(),
             startup_action: StartupAction::default(),
             show_welcome_on_startup: true,
+            reveal_session_toolbar_on_hover: true,
             color_tabs_by_protocol: false,
             show_protocol_filters: false,
             show_smart_folders: false,

--- a/rustconn-core/tests/properties/config_tests.rs
+++ b/rustconn-core/tests/properties/config_tests.rs
@@ -531,6 +531,7 @@ fn arb_full_settings() -> impl Strategy<Value = AppSettings> {
                         search_history: Vec::new(),
                         startup_action: rustconn_core::config::StartupAction::default(),
                         show_welcome_on_startup: true,
+                        reveal_session_toolbar_on_hover: true,
                         color_tabs_by_protocol: false,
                         show_protocol_filters: false,
                         show_smart_folders: false,

--- a/rustconn/src/app.rs
+++ b/rustconn/src/app.rs
@@ -56,6 +56,15 @@ thread_local! {
     /// `manual` forces the compact chrome on always; `auto` engages it only
     /// while a window is small (see [`window_is_small`]).
     static COMPACT_PREFS: Cell<(bool, bool)> = const { Cell::new((false, false)) };
+
+    /// Whether the floating session toolbar opens on pointer hover.
+    ///
+    /// Kept here, next to the compact preferences, for the same reason: an
+    /// embedded RDP/VNC view is built by a constructor that takes no settings,
+    /// and threading `AppSettings` through every one of them to carry a single
+    /// boolean would be worse than reading it where it is needed. Mirrors
+    /// `ui.reveal_session_toolbar_on_hover`.
+    static REVEAL_TOOLBAR_ON_HOVER: Cell<bool> = const { Cell::new(true) };
 }
 
 /// Auto-compact engages when the window is no taller than this (logical px).
@@ -119,6 +128,23 @@ pub fn set_compact_prefs(manual: bool, auto: bool) {
     for window in gtk_app.windows() {
         set_window_compact(&window, manual, auto);
     }
+}
+
+/// Stores whether hovering the session-toolbar handle reveals the toolbar.
+///
+/// Call after the settings toggle changes. Sessions opened from here on pick it
+/// up; an embedded view already on screen keeps the behaviour it was built with,
+/// which is what the settings row tells the user.
+pub fn set_reveal_toolbar_on_hover(enabled: bool) {
+    REVEAL_TOOLBAR_ON_HOVER.with(|pref| pref.set(enabled));
+}
+
+/// Whether hovering the session-toolbar handle should reveal the toolbar.
+///
+/// Read when an embedded RDP/VNC view builds its toolbar controller.
+#[must_use]
+pub fn reveal_toolbar_on_hover() -> bool {
+    REVEAL_TOOLBAR_ON_HOVER.with(Cell::get)
 }
 
 /// Attaches a size watcher so auto-compact reacts live to window resizing.
@@ -281,6 +307,7 @@ fn build_ui(app: &adw::Application, tray_manager: SharedTrayManager) {
         (ui.compact_ui, ui.compact_auto)
     };
     set_compact_prefs(compact_manual, compact_auto);
+    set_reveal_toolbar_on_hover(state.borrow().settings().ui.reveal_session_toolbar_on_hover);
 
     // Initialize tray icon if enabled in settings
     let enable_tray = state.borrow().settings().ui.enable_tray_icon;

--- a/rustconn/src/dialogs/settings/mod.rs
+++ b/rustconn/src/dialogs/settings/mod.rs
@@ -124,6 +124,7 @@ pub struct SettingsDialog {
     compact_ui: adw::SwitchRow,
     // Automatic compact interface on small windows
     compact_auto: adw::SwitchRow,
+    reveal_toolbar_on_hover: adw::SwitchRow,
     // Send terminal control shortcuts to the session toggle (focus-based suspend)
     terminal_passthrough_ctrl: adw::SwitchRow,
     // Show active connection name in the window title (issue #211)
@@ -256,6 +257,7 @@ impl SettingsDialog {
             window_title_shows_connection,
             show_welcome_switch,
             double_click_opens_new_session,
+            reveal_toolbar_on_hover,
             renderer_row,
         ) = create_ui_page();
         mark("ui_page");
@@ -682,6 +684,7 @@ impl SettingsDialog {
             window_title_shows_connection,
             show_welcome_switch,
             double_click_opens_new_session,
+            reveal_toolbar_on_hover,
             renderer_row,
             ssh_agent_status_label,
             ssh_agent_socket_label,
@@ -1032,6 +1035,7 @@ impl SettingsDialog {
             &self.window_title_shows_connection,
             &self.show_welcome_switch,
             &self.double_click_opens_new_session,
+            &self.reveal_toolbar_on_hover,
             &self.renderer_row,
             &settings.ui,
             &conn_refs,
@@ -1183,6 +1187,7 @@ impl SettingsDialog {
         let window_title_shows_connection_clone = self.window_title_shows_connection.clone();
         let show_welcome_switch_clone = self.show_welcome_switch.clone();
         let double_click_opens_new_session_clone = self.double_click_opens_new_session.clone();
+        let reveal_toolbar_on_hover_clone = self.reveal_toolbar_on_hover.clone();
         let renderer_row_clone = self.renderer_row.clone();
         let connections_clone = self.connections.clone();
         let keybindings_overrides_clone = self.keybindings_overrides.clone();
@@ -1336,6 +1341,7 @@ impl SettingsDialog {
                 &window_title_shows_connection_clone,
                 &show_welcome_switch_clone,
                 &double_click_opens_new_session_clone,
+                &reveal_toolbar_on_hover_clone,
                 &renderer_row_clone,
                 &conn_refs,
             );
@@ -1368,6 +1374,14 @@ impl SettingsDialog {
             }
             drop(conn_refs);
             drop(conn_list);
+
+            // Applied on save, not on toggle. The compact switches above are a
+            // live preview — their effect is a CSS class, instantly reversible
+            // and visible while the dialog is still open. This one only changes
+            // how the *next* session is built, so previewing it would buy
+            // nothing and a cancelled dialog would leave the running process
+            // disagreeing with what is on disk.
+            crate::app::set_reveal_toolbar_on_hover(ui.reveal_session_toolbar_on_hover);
 
             // Create new settings
             let new_settings = AppSettings {

--- a/rustconn/src/dialogs/settings/ui_tab.rs
+++ b/rustconn/src/dialogs/settings/ui_tab.rs
@@ -47,6 +47,7 @@ pub fn create_ui_page() -> (
     adw::SwitchRow,
     adw::SwitchRow,
     adw::SwitchRow,
+    adw::SwitchRow,
     adw::ComboRow,
 ) {
     let page = adw::PreferencesPage::builder()
@@ -224,6 +225,19 @@ pub fn create_ui_page() -> (
         ))
         .build();
     appearance_group.add(&compact_auto);
+
+    // Reveal-on-hover for the floating session toolbar. The handle sits at the
+    // top centre of an embedded RDP/VNC view, so aiming at the remote window's
+    // own title bar or close button opens a panel over the very spot being
+    // aimed at. Turning this off keeps the handle and every action — it just
+    // asks for a click.
+    let reveal_toolbar_on_hover = adw::SwitchRow::builder()
+        .title(i18n("Open session toolbar on hover"))
+        .subtitle(i18n(
+            "Reveal the floating RDP/VNC toolbar when the pointer touches its handle. When off, the handle must be clicked",
+        ))
+        .build();
+    appearance_group.add(&reveal_toolbar_on_hover);
 
     // Live preview: both toggles feed the same recompute so the effect is
     // visible before the dialog is saved.
@@ -418,6 +432,7 @@ pub fn create_ui_page() -> (
         window_title_shows_connection,
         show_welcome_switch,
         double_click_opens_new_session,
+        reveal_toolbar_on_hover,
         // Last so that the neighbouring positional arguments in load/collect
         // are SwitchRows: a ComboRow cannot be swapped with one by mistake.
         renderer_row,
@@ -474,6 +489,7 @@ pub fn load_ui_settings(
     window_title_shows_connection: &adw::SwitchRow,
     show_welcome_switch: &adw::SwitchRow,
     double_click_opens_new_session: &adw::SwitchRow,
+    reveal_toolbar_on_hover: &adw::SwitchRow,
     renderer_row: &adw::ComboRow,
     settings: &UiSettings,
     connections: &[&Connection],
@@ -554,6 +570,11 @@ pub fn load_ui_settings(
 
     double_click_opens_new_session.set_active(settings.double_click_opens_new_session);
 
+    // Same shape as the compact toggle above: push the stored value into the
+    // process preference too, so a session opened straight after startup gets
+    // the saved behaviour without waiting for the dialog to be saved.
+    reveal_toolbar_on_hover.set_active(settings.reveal_session_toolbar_on_hover);
+    crate::app::set_reveal_toolbar_on_hover(settings.reveal_session_toolbar_on_hover);
     // Sync the Rendering combo with the saved preference. An unknown variant
     // (a config from a newer build) falls back to the first row, Automatic.
     let renderer_index = RENDERER_ORDER
@@ -611,6 +632,7 @@ pub fn collect_ui_settings(
     window_title_shows_connection: &adw::SwitchRow,
     show_welcome_switch: &adw::SwitchRow,
     double_click_opens_new_session: &adw::SwitchRow,
+    reveal_toolbar_on_hover: &adw::SwitchRow,
     renderer_row: &adw::ComboRow,
     connections: &[&Connection],
 ) -> UiSettings {
@@ -680,5 +702,6 @@ pub fn collect_ui_settings(
         window_title_shows_connection: window_title_shows_connection.is_active(),
         show_welcome_on_startup: show_welcome_switch.is_active(),
         double_click_opens_new_session: double_click_opens_new_session.is_active(),
+        reveal_session_toolbar_on_hover: reveal_toolbar_on_hover.is_active(),
     }
 }

--- a/rustconn/src/embedded_toolbar_overflow.rs
+++ b/rustconn/src/embedded_toolbar_overflow.rs
@@ -300,6 +300,13 @@ impl ToolbarAutoHide {
     /// hovering or clicking it reveals the full toolbar. `handle` decides which
     /// part of that edge it sits on; see [`RevealHandle`] for why the viewers do
     /// not agree.
+    ///
+    /// The hover half of that trigger honours
+    /// `ui.reveal_session_toolbar_on_hover`, read live on each pointer entry.
+    /// With it off the handle still shows, still takes focus and still opens the
+    /// toolbar when clicked — only the pointer-proximity trigger is dropped, so
+    /// approaching the top of a remote desktop no longer opens a panel over the
+    /// spot being aimed at.
     #[must_use]
     pub fn attach(
         overlay: &Overlay,
@@ -347,10 +354,18 @@ impl ToolbarAutoHide {
             }
         });
 
-        // Hovering over the arrow reveals the toolbar without a click.
+        // Hovering over the arrow reveals the toolbar without a click, unless
+        // the user asked for the click to be required. The preference is read
+        // per event rather than captured here on purpose: an embedded session
+        // is long-lived, and a setting that only took effect on sessions opened
+        // afterwards would leave the very session the user is complaining about
+        // behaving the old way until they tore it down and reconnected.
         let reveal_motion = EventControllerMotion::new();
         let controller_weak = Rc::downgrade(&controller);
         reveal_motion.connect_enter(move |_, _, _| {
+            if !crate::app::reveal_toolbar_on_hover() {
+                return;
+            }
             if let Some(controller) = controller_weak.upgrade() {
                 controller.pointer_in_reveal_button.set(true);
                 controller.show();
@@ -359,6 +374,9 @@ impl ToolbarAutoHide {
         let controller_weak = Rc::downgrade(&controller);
         reveal_motion.connect_leave(move |_| {
             if let Some(controller) = controller_weak.upgrade() {
+                // Runs unconditionally: the flag may have been set while the
+                // preference was still on, and leaving it stuck true would hold
+                // the auto-hide timer open forever.
                 controller.pointer_in_reveal_button.set(false);
                 controller.schedule_hide();
             }


### PR DESCRIPTION
The floating toolbar of an embedded RDP/VNC view is revealed by a handle
at the top centre of the remote screen, and merely touching that handle
with the pointer opens the toolbar. That is the worst possible place for
a hover trigger: reaching for the remote window's own title bar, its
close button, or a maximised application's menu drags the pointer across
the handle and drops a panel over the exact spot being aimed at. The
toolbar then swallows the click that was meant for the remote desktop.

Add `ui.reveal_session_toolbar_on_hover`, default `true` so existing
behaviour is unchanged, with a switch in Settings -> Interface. With it
off the handle still shows, still takes focus with Tab and still opens
the toolbar when clicked — only the pointer-proximity trigger is gone.

The preference is read per event rather than captured when the view is
built: an embedded session is long-lived, and a setting that only applied
to sessions opened afterwards would leave the very session the user is
complaining about behaving the old way until they tore it down.

It is applied on save rather than on toggle. The compact-interface
switches next to it are a live preview because their effect is a CSS
class, instantly reversible while the dialog is open; this one changes
how input is routed, so a cancelled dialog must not leave the running
process disagreeing with what is on disk.

Applies to both RDP and VNC, which share the same toolbar controller.



**Note on translations:** this adds two user-visible strings, so `scripts/check-po-complete.sh` will fail until the 16 catalogues are updated. I deliberately did not machine-translate them — that is precisely what that script’s own docstring warns about. Happy to adjust the wording if you prefer different phrasing before it goes through your translation flow.
---

Verified on the Flatpak build (GNOME 50 runtime, `packaging/flatpak/…local.yml`): `cargo fmt --check`, `cargo clippy --workspace --bins --tests` (pedantic + nursery, no warnings) and the test suites pass. This branch also compiles standalone on top of `main`, independently of the other branches I am opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
