### PR TITLE
fix(vault): look the credential up under the key it was saved with

### DIFF
--- a/rustconn/src/state/mod.rs
+++ b/rustconn/src/state/mod.rs
@@ -971,57 +971,100 @@ impl AppState {
             )
         {
             let backend_type = select_backend_for_load(&secret_settings);
-            let lookup_key = generate_store_key(
+            let protocol_str = connection
+                .protocol_config
+                .protocol_type()
+                .as_str()
+                .to_lowercase();
+
+            // Look the credential up where it is written. Saving goes through
+            // `generate_store_key_with_group`, which for keyring backends
+            // produces `RustConn/{group_path}/{name} ({protocol})`; resolving
+            // used `generate_store_key`, which passes no group and produces the
+            // flat `{name} ({protocol})`. So a password saved normally was
+            // searched for at a key nothing is written to any more: the lookup
+            // reported "no password found", and the connection fell through to
+            // the credential prompt with the secret sitting in the keyring the
+            // whole time. Same defect the doc comment on
+            // `generate_store_key_with_group` records for the macOS Keychain in
+            // 0.19.19 — the load side of it was left behind.
+            let group_path = connection.group_id.map(|group_id| {
+                rustconn_core::secret::KeePassHierarchy::resolve_group_path(group_id, groups)
+                    .join("/")
+            });
+            let hierarchical_key = generate_store_key_with_group(
                 &connection.name,
                 &connection.host,
-                &connection
-                    .protocol_config
-                    .protocol_type()
-                    .as_str()
-                    .to_lowercase(),
+                &protocol_str,
+                backend_type,
+                group_path.as_deref(),
+            );
+            // Tried second so credentials written by a release that stored flat
+            // keep resolving, exactly as `resolve_from_keyring_hierarchical`
+            // falls back for the keyring backends it handles.
+            let legacy_key = generate_store_key(
+                &connection.name,
+                &connection.host,
+                &protocol_str,
                 backend_type,
             );
 
-            tracing::debug!(
-                lookup_key = %lookup_key,
-                ?backend_type,
-                "[resolve_credentials_blocking] Vault (non-KeePass): resolving"
-            );
+            let mut lookup_keys = vec![hierarchical_key.clone()];
+            if legacy_key != hierarchical_key {
+                lookup_keys.push(legacy_key);
+            }
 
-            match dispatch_vault_op(&secret_settings, &lookup_key, VaultOp::Retrieve) {
-                Ok(Some(creds)) => {
-                    tracing::debug!("[resolve_credentials_blocking] Found password in vault");
-                    return Ok(CredentialResolutionResult::Resolved(creds));
-                }
-                Ok(None) => {
-                    tracing::debug!("[resolve_credentials_blocking] No password found in vault");
-                    // Vault entry not found — return specific result so UI can prompt
-                    let protocol_str = connection
-                        .protocol_config
-                        .protocol_type()
-                        .as_str()
-                        .to_lowercase();
-                    return Ok(CredentialResolutionResult::VaultEntryMissing {
-                        connection_name: connection.name.clone(),
-                        lookup_key: generate_store_key(
-                            &connection.name,
-                            &connection.host,
-                            &protocol_str,
-                            backend_type,
-                        ),
-                    });
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        "[resolve_credentials_blocking] Vault lookup failed"
-                    );
-                    // Backend may not be properly configured
-                    return Ok(CredentialResolutionResult::BackendNotConfigured {
-                        required_backend: secret_settings.preferred_backend,
-                    });
+            for lookup_key in &lookup_keys {
+                tracing::debug!(
+                    lookup_key = %lookup_key,
+                    ?backend_type,
+                    "[resolve_credentials_blocking] Vault (non-KeePass): resolving"
+                );
+
+                match dispatch_vault_op(&secret_settings, lookup_key, VaultOp::Retrieve) {
+                    // An entry holding an empty password is not a hit. Older
+                    // releases left such entries behind under the flat key, and
+                    // accepting one would end the search before the key that
+                    // actually holds the secret is tried.
+                    Ok(Some(creds))
+                        if creds
+                            .password
+                            .as_ref()
+                            .is_some_and(|password| !password.expose_secret().is_empty()) =>
+                    {
+                        tracing::debug!(
+                            lookup_key = %lookup_key,
+                            "[resolve_credentials_blocking] Found password in vault"
+                        );
+                        return Ok(CredentialResolutionResult::Resolved(creds));
+                    }
+                    Ok(_) => {
+                        tracing::debug!(
+                            lookup_key = %lookup_key,
+                            "[resolve_credentials_blocking] No password under this key"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "[resolve_credentials_blocking] Vault lookup failed"
+                        );
+                        // Backend may not be properly configured
+                        return Ok(CredentialResolutionResult::BackendNotConfigured {
+                            required_backend: secret_settings.preferred_backend,
+                        });
+                    }
                 }
             }
+
+            tracing::debug!("[resolve_credentials_blocking] No password found in vault");
+            // Vault entry not found — return specific result so UI can prompt.
+            // The key reported is the hierarchical one, since that is where a
+            // credential saved from here on will land.
+            return Ok(CredentialResolutionResult::VaultEntryMissing {
+                connection_name: connection.name.clone(),
+                lookup_key: hierarchical_key,
+            });
         }
 
         // For Inherit password source, traverse parent groups to find credentials


### PR DESCRIPTION
Saving a password goes through `generate_store_key_with_group`, which for
keyring backends produces `RustConn/{group_path}/{name} ({protocol})`.
Resolving it went through `generate_store_key`, which passes no group and
produces the flat `{name} ({protocol})`.

So the credential was searched for at a key nothing is written to any
more. The lookup reported "no password found in vault" and the connection
fell through to the credential prompt, with the secret sitting in the
keyring the whole time. Every connection that lives in a group and uses a
keyring backend is affected; only connections at the tree root, where the
two keys coincide, kept working.

Captured on the session bus while connecting, the client searched
`connection_id = "ubuntu-dev (rdp)"` four times over — username, password
and key_passphrase — and never once
`connection_id = "RustConn/all/ubuntu-dev (rdp)"`, which is where the
password had been stored.

The hierarchical key is tried first and the flat one second, the same
order `resolve_from_keyring_hierarchical` already applies for the backends
it handles, so credentials written by a release that stored flat keep
resolving.

An entry whose password is empty no longer counts as a hit: an earlier
release can leave one behind under the flat key, and accepting it ends the
search before the key holding the real secret is tried. That is exactly
what the keyring looked like on the machine this was found on.

This is the load half of the defect the doc comment on
`generate_store_key_with_group` records for the macOS Keychain in 0.19.19
("meant the resolver never looked where the credential had been
written"). The store half was fixed then; this one was left behind.



**Validated in real use**, not only by reading the code: with this applied, an RDP connection in a group stopped prompting and connected with the stored credential, on the same machine where the session-bus capture above was taken.
---

Verified on the Flatpak build (GNOME 50 runtime, `packaging/flatpak/…local.yml`): `cargo fmt --check`, `cargo clippy --workspace --bins --tests` (pedantic + nursery, no warnings) and the test suites pass. This branch also compiles standalone on top of `main`, independently of the other branches I am opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
