### PR TITLE
fix(rdp): set INFO_AUTOLOGON so xrdp skips its own login screen

### DIFF
--- a/rustconn-core/src/rdp_client/client/connection.rs
+++ b/rustconn-core/src/rdp_client/client/connection.rs
@@ -746,7 +746,29 @@ fn build_connector_config(config: &RdpClientConfig) -> Config {
         platform: MajorPlatformType::UNIX,
         hardware_id: None,
         request_data: None,
-        autologon: false,
+        // Ask the server to log the session in with the credentials this PDU
+        // already carries (`INFO_AUTOLOGON`).
+        //
+        // Windows never needed it: the session is established from the
+        // CredSSP/NLA exchange, so the flag being off went unnoticed. xrdp does
+        // need it — its session manager only skips its own login screen when
+        // the flag is set, so connecting to a Linux host got past the first
+        // stage with the password accepted and then stopped at the greeter,
+        // asking for the same credentials again. FreeRDP sets this flag
+        // whenever credentials are supplied, which is why the very same host
+        // logs straight in from Remmina.
+        //
+        // Off when there is nothing to log in with: the flag would promise an
+        // automatic logon the PDU cannot deliver, and a server that trusts it
+        // may drop the connection instead of showing its own prompt.
+        autologon: config
+            .username
+            .as_ref()
+            .is_some_and(|username| !username.is_empty())
+            && config
+                .password
+                .as_ref()
+                .is_some_and(|password| !password.expose_secret().is_empty()),
         enable_audio_playback: config.audio_enabled,
         performance_flags,
         license_cache: None,


### PR DESCRIPTION
The connector config hardcoded `autologon: false`, the ironrdp-client
default. The flag controls `INFO_AUTOLOGON` in the Client Info PDU, which
tells the server the credentials the PDU already carries are meant for an
automatic logon. The credentials were being sent; nothing authorised
their use.

Windows never showed the defect: the session is established from the
CredSSP/NLA exchange, so the flag being off costs nothing there. xrdp
does not work that way — its session manager only skips its own login
screen when the flag is set. Connecting to a Linux host therefore got
past the first stage, with the password accepted, and then stopped at the
xrdp greeter asking for the same credentials again.

FreeRDP sets this flag whenever credentials are supplied, which is why
the very same host logs straight in from Remmina and stalls from the
embedded client.

The flag is set only when both a username and a non-empty password are
available: promising an automatic logon the PDU cannot deliver makes some
servers drop the connection instead of falling back to their own prompt.



**Validated in real use** against both a Windows host (unchanged, still fine) and an Ubuntu host running xrdp, where the session now logs straight in instead of stopping at the xrdp greeter.
---

Verified on the Flatpak build (GNOME 50 runtime, `packaging/flatpak/…local.yml`): `cargo fmt --check`, `cargo clippy --workspace --bins --tests` (pedantic + nursery, no warnings) and the test suites pass. This branch also compiles standalone on top of `main`, independently of the other branches I am opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
