### PR TITLE
fix: add dependency for required libwebkitgtk-6.0-4

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,8 @@ Rules-Requires-Root: no
 Package: rustconn
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
-         openssh-client
+         openssh-client,
+         libwebkitgtk-6.0-4
 Recommends: freerdp2-x11 | freerdp3-x11 | freerdp3-wayland,
             tigervnc-viewer,
             virt-viewer,


### PR DESCRIPTION

## What this changes

Fixes #313
Adds missing dependency

## Why

libwebkitgtk-6.0-4 is not installed by default and is required.

## How it was tested

Untested other than manually installing the dependency so that the installed .deb `rustconn`
binary runs.


## Checklist

- [ ] `cargo fmt --all` clean
- [ ] `cargo clippy --all-targets` reports 0 warnings, from a run that actually re-checked (a cache hit prints `Finished ... in 0.2s` and reports nothing)
- [ ] Relevant tests pass; non-trivial logic has one runnable check
- [ ] Crate boundaries intact — no `gtk4`/`adw`/`vte4` in `rustconn-core` or `rustconn-cli`, no `unsafe` outside a `rustconn-*-sys` crate
- [ ] Secrets use `SecretString`, intermediates are `Zeroizing`, nothing secret reaches a log, an error message, or a command argument
- [ ] New user-facing strings wrapped in `i18n()`/`i18n_f()`, source file listed in `po/POTFILES.in`, `bash po/update-pot.sh` run
- [ ] No `dbg!`, `todo!`, `println!`, or `eprintln!` left behind (`rustconn-cli` excepted — printing is its interface)
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` if the change is user-facing
- [x] Commits follow `type(scope): description`

<!--
If an external blocker (upstream bug, new compiler lint, flaky CI) kept you from
ticking a box, say so here rather than working around it silently.
-->
